### PR TITLE
modified initial heightgraph width

### DIFF
--- a/src/Map/Map.jsx
+++ b/src/Map/Map.jsx
@@ -272,6 +272,7 @@ class Map extends React.Component {
       highlightStyle: {
         color: 'blue',
       },
+      width: window.innerWidth * 0.9,
     })
     this.hg.addTo(this.map)
     const hg = this.hg


### PR DESCRIPTION
We previously did not set an initial width on the height graph, so the svg dimensions were always 800px regardless of device dimensions. This pr addresses that. Caveat: does not change on resize at the moment. 