### PR TITLE
Make settings configurable from .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,9 @@
 SKIP_PREFLIGHT_CHECK=true
+REACT_APP_VALHALLA_URL=https://valhalla1.openstreetmap.de
+REACT_APP_NOMINATIM_URL=https://nominatim.openstreetmap.org
+REACT_APP_TILE_SERVER_URL="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+REACT_APP_CENTER_COORDS="52.51831,13.393707"
+
+# uncomment this variable to set boundaries on the leaflet map
+#                       southwest corner, northeast corner
+# REACT_APP_MAX_BOUNDS="50.51831,10.393707,55.51831,15.393707"

--- a/src/Map/Map.jsx
+++ b/src/Map/Map.jsx
@@ -31,13 +31,10 @@ import {
 } from 'utils/valhalla'
 import { colorMappings, buildHeightgraphData } from 'utils/heightgraph'
 
-const OSMTiles = L.tileLayer(
-  'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-  {
-    attribution:
-      '<a href="https://map.project-osrm.org/about.html" target="_blank">About this service and privacy policy</a> | &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-  }
-)
+const OSMTiles = L.tileLayer(process.env.REACT_APP_TILE_SERVER_URL, {
+  attribution:
+    '<a href="https://map.project-osrm.org/about.html" target="_blank">About this service and privacy policy</a> | &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+})
 
 // defining the container styles the map sits in
 const style = {
@@ -68,9 +65,23 @@ const highlightRouteSegmentlayer = L.featureGroup()
 const highlightRouteIndexLayer = L.featureGroup()
 const excludePolygonsLayer = L.featureGroup()
 
+const centerCoords = process.env.REACT_APP_CENTER_COORDS.split(',')
+const center = [parseFloat(centerCoords[0]), parseFloat(centerCoords[1])]
+
+const maxBoundsString = process.env.REACT_APP_MAX_BOUNDS?.split(',')
+const maxBounds = maxBoundsString
+  ? [
+      //south west corner
+      [parseFloat(maxBoundsString[0]), parseFloat(maxBoundsString[1])],
+      //north east corner
+      [parseFloat(maxBoundsString[2]), parseFloat(maxBoundsString[3])],
+    ]
+  : undefined
+
 // a leaflet map consumes parameters, I'd say they are quite self-explanatory
 const mapParams = {
-  center: [52.51831, 13.393707],
+  center,
+  maxBounds,
   zoomControl: false,
   zoom: 10,
   maxZoom: 18,

--- a/src/components/SettingsButton.jsx
+++ b/src/components/SettingsButton.jsx
@@ -7,7 +7,7 @@ export const SettingsButton = ({ handleSettings }) => {
     <Popup
       content={'Show/hide settings'}
       trigger={
-        <Button tertiary icon onClick={() => handleSettings()}>
+        <Button tertiary="true" icon onClick={() => handleSettings()}>
           <Icon name="cogs" />{' '}
         </Button>
       }

--- a/src/utils/nominatim.js
+++ b/src/utils/nominatim.js
@@ -1,8 +1,7 @@
 import axios from 'axios'
 
-export const NOMINATIM_URL = 'https://nominatim.openstreetmap.org/search'
-export const NOMINATIME_URL_REVERSE =
-  'https://nominatim.openstreetmap.org/reverse'
+export const NOMINATIM_URL = `${process.env.REACT_APP_NOMINATIM_URL}/search`
+export const NOMINATIME_URL_REVERSE = `${process.env.REACT_APP_NOMINATIM_URL}/reverse`
 
 export const forward_geocode = (userInput) =>
   axios.get(NOMINATIM_URL, {

--- a/src/utils/valhalla.js
+++ b/src/utils/valhalla.js
@@ -1,6 +1,6 @@
 import { decode } from './polyline'
 
-export const VALHALLA_OSM_URL = 'https://valhalla1.openstreetmap.de'
+export const VALHALLA_OSM_URL = process.env.REACT_APP_VALHALLA_URL
 
 export const buildLocateRequest = (latLng, profile) => {
   let valhalla_profile = profile


### PR DESCRIPTION
Changes:

* Makes the backend URLs used configurable from `.env`, which can be modified at build time to switch backends used. This is especially useful for self-hosting.
* Read some of the leaflet config from the `.env` file for more dynamic changes.
* Fixes a warning about the type `tertiary` field from the mobile UI PR.

I can make an issue for this, if needed.

Thanks!