### PR TITLE
extend geocoding result content vertically

### DIFF
--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -57,7 +57,7 @@ class Waypoints extends Component {
     this.setState({ visible: true })
 
     if (directions.waypoints.length === 0) {
-      Array(3)
+      Array(2)
         .fill()
         .map((_, i) => dispatch(doAddWaypoint()))
     }

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -32,8 +32,9 @@ const getListStyle = (isDraggingOver) => ({
   width: '100%',
   //height: 200,
   paddingBottom: 20,
-  maxHeight: 80 + 'vh',
-  height: 65 + 'vh',
+  maxHeight: 350,
+  height: 300',
+  oveflow: 'inherit',
 })
 
 class Waypoints extends Component {

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -57,7 +57,7 @@ class Waypoints extends Component {
     this.setState({ visible: true })
 
     if (directions.waypoints.length === 0) {
-      Array(2)
+      Array(3)
         .fill()
         .map((_, i) => dispatch(doAddWaypoint()))
     }

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -89,7 +89,7 @@ class Waypoints extends Component {
           {(provided, snapshot) => (
             <React.Fragment>
               <div
-                className={`flex flex-column overflow-auto`}
+                className={`flex flex-column`}
                 {...provided.droppableProps}
                 ref={provided.innerRef}
                 style={getListStyle(snapshot.isDraggingOver)}

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -32,8 +32,8 @@ const getListStyle = (isDraggingOver) => ({
   width: '100%',
   //height: 200,
   paddingBottom: 20,
-  maxHeight: 350,
-  height: 300,
+  maxHeight: 80 + 'vh',
+  height: 65 'vh',
 })
 
 class Waypoints extends Component {

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -33,7 +33,7 @@ const getListStyle = (isDraggingOver) => ({
   //height: 200,
   paddingBottom: 20,
   maxHeight: 350,
-  height: 300',
+  height: 300,
   oveflow: 'inherit',
 })
 

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -33,7 +33,7 @@ const getListStyle = (isDraggingOver) => ({
   //height: 200,
   paddingBottom: 20,
   maxHeight: 80 + 'vh',
-  height: 65 'vh',
+  height: 65 + 'vh',
 })
 
 class Waypoints extends Component {

--- a/src/components/CustomSlider.jsx
+++ b/src/components/CustomSlider.jsx
@@ -15,7 +15,7 @@ const CustomSlider = (props) => {
 
   const [sliderVal, setSliderVal] = useState(parseFloat(settings[option.param]))
 
- // console.log(sliderVal)
+
   useEffect(() => {
     setSliderVal(parseFloat(settings[option.param]))
   }, [settings, option.param])

--- a/src/components/CustomSlider.jsx
+++ b/src/components/CustomSlider.jsx
@@ -12,9 +12,7 @@ import PropTypes from 'prop-types'
 const CustomSlider = (props) => {
   const { settings, option, profile, handleUpdateSettings } = props
   const { min, max, step } = option.settings
-
   const [sliderVal, setSliderVal] = useState(parseFloat(settings[option.param]))
-
 
   useEffect(() => {
     setSliderVal(parseFloat(settings[option.param]))

--- a/src/components/CustomSlider.jsx
+++ b/src/components/CustomSlider.jsx
@@ -15,7 +15,7 @@ const CustomSlider = (props) => {
 
   const [sliderVal, setSliderVal] = useState(parseFloat(settings[option.param]))
 
-  console.log(sliderVal)
+ // console.log(sliderVal)
   useEffect(() => {
     setSliderVal(parseFloat(settings[option.param]))
   }, [settings, option.param])


### PR DESCRIPTION
  **Issue #53** (EDIT)
 fixes the issue of  sidebar content extend vertically all the way , changed the default overflow:auto to overflow:inherited
**Issue #77**
   fixes the issue of Slider value consoles out its value by deleting out the code 



:
![image](https://user-images.githubusercontent.com/59855919/221518907-27eefb2c-e1c9-4911-8c9a-0947f6f7866a.png)

