### PR TITLE
Removed the via waypoint by default

### DIFF
--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -82,7 +82,6 @@ class Waypoints extends Component {
 
   render() {
     const { waypoints } = this.props.directions
-    console.log('waypoints', waypoints)
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
         <Droppable droppableId="droppable">

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -57,7 +57,7 @@ class Waypoints extends Component {
     this.setState({ visible: true })
 
     if (directions.waypoints.length === 0) {
-      Array(3)
+      Array(2)
         .fill()
         .map((_, i) => dispatch(doAddWaypoint()))
     }
@@ -82,6 +82,7 @@ class Waypoints extends Component {
 
   render() {
     const { waypoints } = this.props.directions
+    console.log('waypoints', waypoints)
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
         <Droppable droppableId="droppable">


### PR DESCRIPTION
When the app loads we have 3 waypoints ( **Destination**, **Origin**, and **Via** ). 

So, the via waypoint can be intentionally added by the user using the + Icon on the bottom of the sidebar.


ScreenShot : 
<img width="809" alt="image" src="https://user-images.githubusercontent.com/65409282/220857956-41e7217a-614f-4385-ab9e-219db7b15d03.png">
For removing the additional via waypoint I changed the value of amount from 3 to 2 when the component first mounted.
