### PR TITLE
Use default value when a user enters a value out of valid range

### DIFF
--- a/src/components/CustomSlider.jsx
+++ b/src/components/CustomSlider.jsx
@@ -22,7 +22,6 @@ const CustomSlider = (props) => {
 
   const handleChange = (value) => {
     // reset
-    // console.log("Before: value", value)
     if (isNaN(value)) {
       value =
         profile === 'truck'
@@ -31,11 +30,9 @@ const CustomSlider = (props) => {
     }
     if (value < min) {
       value = min
-    }
-    if (value > max) {
+    } else if (value > max) {
       value = max
     }
-    // console.log("After: value", value)
     setSliderVal(parseFloat(value))
     debounce(
       300,

--- a/src/components/CustomSlider.jsx
+++ b/src/components/CustomSlider.jsx
@@ -22,12 +22,20 @@ const CustomSlider = (props) => {
 
   const handleChange = (value) => {
     // reset
+    // console.log("Before: value", value)
     if (isNaN(value)) {
       value =
         profile === 'truck'
           ? settingsInitTruckOverride[option.param]
           : settingsInit[option.param]
     }
+    if (value < min) {
+      value = min
+    }
+    if (value > max) {
+      value = max
+    }
+    // console.log("After: value", value)
     setSliderVal(parseFloat(value))
     debounce(
       300,


### PR DESCRIPTION
### Pull Request Description
* Issues: #45 
* Fix Description: 
  * When a user enters a value out of a `profile_settings` `[min , max]` range, the input value is clamped at the extremes of the range