### PR TITLE
fix: results vertical ordering w.r.t active tab

### DIFF
--- a/src/Controls/Isochrones/OutputControl.jsx
+++ b/src/Controls/Isochrones/OutputControl.jsx
@@ -36,7 +36,7 @@ class OutputControl extends React.Component {
     return (
       <Segment
         style={{
-          margin: '0 1rem',
+          margin: '0 1rem 10px',
           display: successful ? 'block' : 'none',
         }}
       >

--- a/src/Controls/index.jsx
+++ b/src/Controls/index.jsx
@@ -219,6 +219,7 @@ class MainControl extends React.Component {
                 <ServiceTabs />
               </div>
             </Segment>
+            {/* because apparently on small screens it's not showing both, so we switch the order on tab switch */}
             {(activeTab === 0 && (
               <>
                 <DirectionOutputControl />

--- a/src/Controls/index.jsx
+++ b/src/Controls/index.jsx
@@ -219,8 +219,17 @@ class MainControl extends React.Component {
                 <ServiceTabs />
               </div>
             </Segment>
-            <DirectionOutputControl />
-            <IsochronesOutputControl />
+            {(activeTab === 0 && (
+              <>
+                <DirectionOutputControl />
+                <IsochronesOutputControl />
+              </>
+            )) || (
+              <>
+                <IsochronesOutputControl />
+                <DirectionOutputControl />
+              </>
+            )}
           </div>
         </Drawer>
         <SemanticToastContainer position="bottom-center" />


### PR DESCRIPTION
**Fixes issue**
closes #78 

With respect to the active tab we are showing results at the bottom in the respective order.

**Screenshot**
https://www.awesomescreenshot.com/video/15283492?key=f6d41803f4749982e1d2c825d8131e03 