### PR TITLE
Download Icon changed to Copy Icon for Clipboard copy in Settings Sidebar.

### DIFF
--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -82,7 +82,6 @@ class Waypoints extends Component {
 
   render() {
     const { waypoints } = this.props.directions
-    console.log('waypoints', waypoints)
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
         <Droppable droppableId="droppable">

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -57,7 +57,7 @@ class Waypoints extends Component {
     this.setState({ visible: true })
 
     if (directions.waypoints.length === 0) {
-      Array(3)
+      Array(2)
         .fill()
         .map((_, i) => dispatch(doAddWaypoint()))
     }
@@ -82,6 +82,7 @@ class Waypoints extends Component {
 
   render() {
     const { waypoints } = this.props.directions
+    console.log('waypoints', waypoints)
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
         <Droppable droppableId="droppable">

--- a/src/Controls/settings-panel.jsx
+++ b/src/Controls/settings-panel.jsx
@@ -414,7 +414,7 @@ class SettingsPanel extends React.Component {
                       color={this.state.copied ? 'green' : undefined}
                       labelPosition="left"
                     >
-                      <Icon name="download" />
+                      <Icon name="copy" />
                       Copy to Clipboard
                     </Button>
                   </CopyToClipboard>


### PR DESCRIPTION
In the settings panel, we can see the download icon for copying the text to the clipboard.

<img width="314" alt="downloadicon" src="https://user-images.githubusercontent.com/65409282/223026830-b669703e-f33f-4a41-8643-12182258333c.png">

I think that icon is simply used when we download something, not copy something.
So, I think it should be changed to copy icon. After changing it looks like this


<img width="292" alt="copyicon" src="https://user-images.githubusercontent.com/65409282/223026984-38ec428e-668c-424e-a10a-cce836de7c44.png">

Also, In this app for copying something in the clipboard we used copy icon throughout the app. For example:

<img width="299" alt="image" src="https://user-images.githubusercontent.com/65409282/223027467-504c890c-6164-4486-bf6a-ee7854fca012.png">

So, I think we should follow the same icon for the same type of procedure otherwise users can get confused about whether they are copying something or something will get downloaded after clicking on the icon.  
