### PR TITLE
Added Timeout For Colour in Copy clipboard (In Settings Sidebar Tab)

### DIFF
--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -82,7 +82,6 @@ class Waypoints extends Component {
 
   render() {
     const { waypoints } = this.props.directions
-    console.log('waypoints', waypoints)
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
         <Droppable droppableId="droppable">

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -57,7 +57,7 @@ class Waypoints extends Component {
     this.setState({ visible: true })
 
     if (directions.waypoints.length === 0) {
-      Array(3)
+      Array(2)
         .fill()
         .map((_, i) => dispatch(doAddWaypoint()))
     }
@@ -82,6 +82,7 @@ class Waypoints extends Component {
 
   render() {
     const { waypoints } = this.props.directions
+    console.log('waypoints', waypoints)
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
         <Droppable droppableId="droppable">

--- a/src/Controls/settings-panel.jsx
+++ b/src/Controls/settings-panel.jsx
@@ -145,6 +145,13 @@ class SettingsPanel extends React.Component {
     this.setState({ [settingsType]: settings })
   }
 
+  handleColorCopy = () => {
+    this.setState({ copied: true })
+    setTimeout(() => {
+      this.setState({ copied: false })
+    }, 1000) // 1 seconds
+  }
+
   handleBikeTypeChange = (e, data) => {
     const { value, name } = data
     const { dispatch } = this.props
@@ -405,7 +412,7 @@ class SettingsPanel extends React.Component {
                 <Grid.Column width={16}>
                   <CopyToClipboard
                     text={this.extractSettings(profile, settings)}
-                    onCopy={() => this.setState({ copied: true })}
+                    onCopy={this.handleColorCopy}
                   >
                     <Button
                       basic

--- a/src/Controls/settings-panel.jsx
+++ b/src/Controls/settings-panel.jsx
@@ -414,7 +414,7 @@ class SettingsPanel extends React.Component {
                       color={this.state.copied ? 'green' : undefined}
                       labelPosition="left"
                     >
-                      <Icon name="download" />
+                      <Icon name="copy" />
                       Copy to Clipboard
                     </Button>
                   </CopyToClipboard>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

In the setting tab, when we click on copy to clipboard we can see that its color changes to green which is a good user experience. However, it stays Green throughout the application unless the user leaves the platform or refreshes the page.
Even if we click again on the "copy to clipboard", it stays the same, which is obviously not a good user experience.




## 👨‍💻 Changes proposed

I would like it to automatically change to its original color after 1 second or 2 seconds for a better user experience. So, I am suggesting adding a timeout of 1 second, after 1 second **state: copied** will get changed to false, and so do the color.


## 📄 Note to reviewers

Actually, I noticed this issue just after my previous pull request, otherwise, I would have solved this in that previous PR itself.


## 📷 Screenshots

Before : 

![Untitled video - Made with Clipchamp](https://user-images.githubusercontent.com/65409282/223119623-50bd26b7-5b64-4d96-bbd2-d88776499980.gif)


After changes : 

![after](https://user-images.githubusercontent.com/65409282/223120531-69369e88-194b-4b4d-aebf-d8449975f45a.gif)
