### PR TITLE
Improved control tabs in Left side panel

### DIFF
--- a/src/Controls/Isochrones/Waypoints/index.jsx
+++ b/src/Controls/Isochrones/Waypoints/index.jsx
@@ -247,7 +247,7 @@ class Waypoints extends Component {
             </Accordion.Title>
             <Accordion.Content active={activeIndex === 0}>
               <Form size={'small'}>
-                <div className={'pt3 pl3'}>
+                <div className={'pt3 pl3 pr3'}>
                   <Form.Group inline>
                     <Form.Input
                       width={12}
@@ -314,7 +314,7 @@ class Waypoints extends Component {
                     />
                   </div>
                 </div>
-                <div className={'pt3 pl3'}>
+                <div className={'pt3 pl3 pr3'}>
                   <Form.Group inline>
                     <Form.Input
                       width={12}

--- a/src/index.css
+++ b/src/index.css
@@ -61,3 +61,11 @@ i.help.grey.icon {
   font-size: 12px;
   font-weight: bold;
 }
+
+.ui.menu .item{
+  width: 50%;
+}
+
+.ui.menu:not(.vertical) .item{
+  justify-content: center;
+}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue
Closes #88 

<!-- Example: Closes #31 -->

## 👨‍💻 Changes proposed

1. The directions and isochrones button were not fully occupying the width, So I extended them to use full width. (See images)
2. The slider in setting in Isochrones section was having a padding-left but not padding-right due to which it was not looking good. I added padding-right also so it aligns in the center with equidistance from both sides.

## 📄 Note to reviewers

While I was roaming in the code base, I found that most of the part of CSS is not written properly, changing one part affects another part adversely. Can I start writing my proposal around refactoring most of the codebase (mostly CSS and adding some new functionalities also) so that it would be written in accordance of standard practices.

## 📷 Screenshots

1. Before:
![image](https://user-images.githubusercontent.com/82600388/223196039-ffc571b9-3a6d-488f-962e-5de39993b94d.png)
After:  
![image](https://user-images.githubusercontent.com/82600388/223196094-dba6ec0e-3b3e-4dd9-b855-20db72d49b84.png)

2. Before: 
![image](https://user-images.githubusercontent.com/82600388/223196202-200656ab-72cc-452a-a3cb-322037597a78.png)
After:  
![image](https://user-images.githubusercontent.com/82600388/223196293-9e104255-af84-4e6b-8ae0-6afc018f6e64.png)

