### PR TITLE
Fixed [BUG] Directions Waypoint overflow #99

### DIFF
--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -94,7 +94,7 @@ class Waypoints extends Component {
                 }`}
                 {...provided.droppableProps}
                 ref={provided.innerRef}
-                 style={getListStyle(snapshot.isDraggingOver, isExtendedList)}
+                style={getListStyle(snapshot.isDraggingOver, isExtendedList)}
               >
                 {waypoints.map((wp, index) => (
                   <Draggable key={wp.id} draggableId={wp.id} index={index}>

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -111,14 +111,14 @@ class Waypoints extends Component {
               >
                 {waypoints.map((wp, index) => (
                   <Draggable key={wp.id} draggableId={wp.id} index={index}>
-                    {(provided, snapshot) => (
+                    {(provided_inner, snapshot_inner) => (
                       <div
-                        ref={provided.innerRef}
-                        {...provided.draggableProps}
-                        {...provided.dragHandleProps}
+                        ref={provided_inner.innerRef}
+                        {...provided_inner.draggableProps}
+                        {...provided_inner.dragHandleProps}
                         style={getItemStyle(
-                          snapshot.isDragging,
-                          provided.draggableProps.style
+                          snapshot_inner.isDragging,
+                          provided_inner.draggableProps.style
                         )}
                       >
                         <Waypoint

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -94,7 +94,7 @@ class Waypoints extends Component {
                 }`}
                 {...provided.droppableProps}
                 ref={provided.innerRef}
-                 style={getListStyle(snapshot.isDraggingOver)}
+                 style={getListStyle(snapshot.isDraggingOver, isExtendedList)}
               >
                 {waypoints.map((wp, index) => (
                   <Draggable key={wp.id} draggableId={wp.id} index={index}>

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -57,7 +57,7 @@ class Waypoints extends Component {
     this.setState({ visible: true })
 
     if (directions.waypoints.length === 0) {
-      Array(3)
+      Array(2)
         .fill()
         .map((_, i) => dispatch(doAddWaypoint()))
     }

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -34,7 +34,14 @@ const getListStyle = (isDraggingOver) => ({
   paddingBottom: 20,
   maxHeight: 350,
   height: 300,
-  oveflow: 'inherit',
+})
+const ExtendedListStyle = (isDraggingOver) => ({
+  //background: isDraggingOver ? 'lightblue' : 'lightgrey',
+  width: '100%',
+  //height: 200,
+  paddingBottom: 20,
+  maxHeight: 80 + 'vh',
+  height: 60 + 'vh',
 })
 
 class Waypoints extends Component {
@@ -83,27 +90,35 @@ class Waypoints extends Component {
 
   render() {
     const { waypoints } = this.props.directions
+    const isExtendedList = waypoints.length > 6 || waypoints.length === 6
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
         <Droppable droppableId="droppable">
           {(provided, snapshot) => (
             <React.Fragment>
               <div
-                className={`flex flex-column`}
+                className={`flex 
+                ${
+                  isExtendedList ? 'flex-column overflow-auto' : 'flex-column'
+                }`}
                 {...provided.droppableProps}
                 ref={provided.innerRef}
-                style={getListStyle(snapshot.isDraggingOver)}
+                style={
+                  isExtendedList
+                    ? ExtendedListStyle(snapshot.isDraggingOver)
+                    : getListStyle(snapshot.isDraggingOver)
+                }
               >
                 {waypoints.map((wp, index) => (
                   <Draggable key={wp.id} draggableId={wp.id} index={index}>
-                    {(provided_inner, snapshot_inner) => (
+                    {(provided, snapshot) => (
                       <div
-                        ref={provided_inner.innerRef}
-                        {...provided_inner.draggableProps}
-                        {...provided_inner.dragHandleProps}
+                        ref={provided.innerRef}
+                        {...provided.draggableProps}
+                        {...provided.dragHandleProps}
                         style={getItemStyle(
-                          snapshot_inner.isDragging,
-                          provided_inner.draggableProps.style
+                          snapshot.isDragging,
+                          provided.draggableProps.style
                         )}
                       >
                         <Waypoint

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -32,8 +32,9 @@ const getListStyle = (isDraggingOver) => ({
   width: '100%',
   //height: 200,
   paddingBottom: 20,
-  maxHeight: 80 + 'vh',
-  height: 65 + 'vh',
+  maxHeight: 350,
+  height: 300',
+  oveflow: 'inherit',
 })
 
 class Waypoints extends Component {

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -81,7 +81,7 @@ class Waypoints extends Component {
 
   render() {
     const { waypoints } = this.props.directions
-    const isExtendedList = waypoints.length > 6 || waypoints.length === 6
+    const isExtendedList = waypoints.length >= 6
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
         <Droppable droppableId="droppable">

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -57,7 +57,7 @@ class Waypoints extends Component {
     this.setState({ visible: true })
 
     if (directions.waypoints.length === 0) {
-      Array(2)
+      Array(3)
         .fill()
         .map((_, i) => dispatch(doAddWaypoint()))
     }

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -89,7 +89,7 @@ class Waypoints extends Component {
           {(provided, snapshot) => (
             <React.Fragment>
               <div
-                className={`flex flex-column overflow-auto`}
+                className={`flex flex-column`}
                 {...provided.droppableProps}
                 ref={provided.innerRef}
                 style={getListStyle(snapshot.isDraggingOver)}

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -32,8 +32,8 @@ const getListStyle = (isDraggingOver) => ({
   width: '100%',
   //height: 200,
   paddingBottom: 20,
-  maxHeight: 350,
-  height: 300,
+  maxHeight: 80 + 'vh',
+  height: 65 'vh',
 })
 
 class Waypoints extends Component {

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -27,21 +27,12 @@ const getItemStyle = (isDragging, draggableStyle) => ({
   ...draggableStyle,
 })
 
-const getListStyle = (isDraggingOver) => ({
+const getListStyle = (isDraggingOver, isExtendedList) => ({
   //background: isDraggingOver ? 'lightblue' : 'lightgrey',
   width: '100%',
-  //height: 200,
   paddingBottom: 20,
-  maxHeight: 350,
-  height: 300,
-})
-const ExtendedListStyle = (isDraggingOver) => ({
-  //background: isDraggingOver ? 'lightblue' : 'lightgrey',
-  width: '100%',
-  //height: 200,
-  paddingBottom: 20,
-  maxHeight: 80 + 'vh',
-  height: 60 + 'vh',
+  maxHeight: isExtendedList ? '80vh' : '350px',
+  height: isExtendedList ? '60vh' : '300px',
 })
 
 class Waypoints extends Component {
@@ -103,11 +94,7 @@ class Waypoints extends Component {
                 }`}
                 {...provided.droppableProps}
                 ref={provided.innerRef}
-                style={
-                  isExtendedList
-                    ? ExtendedListStyle(snapshot.isDraggingOver)
-                    : getListStyle(snapshot.isDraggingOver)
-                }
+                 style={getListStyle(snapshot.isDraggingOver)}
               >
                 {waypoints.map((wp, index) => (
                   <Draggable key={wp.id} draggableId={wp.id} index={index}>

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -33,7 +33,7 @@ const getListStyle = (isDraggingOver) => ({
   //height: 200,
   paddingBottom: 20,
   maxHeight: 350,
-  height: 300',
+  height: 300,
   oveflow: 'inherit',
 })
 

--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -33,7 +33,7 @@ const getListStyle = (isDraggingOver) => ({
   //height: 200,
   paddingBottom: 20,
   maxHeight: 80 + 'vh',
-  height: 65 'vh',
+  height: 65 + 'vh',
 })
 
 class Waypoints extends Component {

--- a/src/components/CustomSlider.jsx
+++ b/src/components/CustomSlider.jsx
@@ -15,7 +15,7 @@ const CustomSlider = (props) => {
 
   const [sliderVal, setSliderVal] = useState(parseFloat(settings[option.param]))
 
- // console.log(sliderVal)
+
   useEffect(() => {
     setSliderVal(parseFloat(settings[option.param]))
   }, [settings, option.param])

--- a/src/components/CustomSlider.jsx
+++ b/src/components/CustomSlider.jsx
@@ -12,9 +12,7 @@ import PropTypes from 'prop-types'
 const CustomSlider = (props) => {
   const { settings, option, profile, handleUpdateSettings } = props
   const { min, max, step } = option.settings
-
   const [sliderVal, setSliderVal] = useState(parseFloat(settings[option.param]))
-
 
   useEffect(() => {
     setSliderVal(parseFloat(settings[option.param]))

--- a/src/components/CustomSlider.jsx
+++ b/src/components/CustomSlider.jsx
@@ -15,7 +15,7 @@ const CustomSlider = (props) => {
 
   const [sliderVal, setSliderVal] = useState(parseFloat(settings[option.param]))
 
-  console.log(sliderVal)
+ // console.log(sliderVal)
   useEffect(() => {
     setSliderVal(parseFloat(settings[option.param]))
   }, [settings, option.param])


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue
Closes #99 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## 👨‍💻 Changes proposed
Since the directions were overflowing whenever we get more than 6 waypoints(checked across all devices) , so whenever there are more than 6 waypoints , the overflow automatically gets set to auto. Hence the problem is solved. 
It Also increases the height of the box to look User-Friendly.
<!-- List all the proposed changes in your PR -->

## 📄 Note to reviewers

<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots

https://user-images.githubusercontent.com/59855919/223726603-70ccae72-d305-48f5-8348-6327c38519a1.mp4


<!-- Add any relevant screenshots if applicable -->
