### PR TITLE
Fixes Search Results Trapped Inside Scrolling #123

### DIFF
--- a/src/Controls/Directions/Waypoints/index.jsx
+++ b/src/Controls/Directions/Waypoints/index.jsx
@@ -27,14 +27,6 @@ const getItemStyle = (isDragging, draggableStyle) => ({
   ...draggableStyle,
 })
 
-const getListStyle = (isDraggingOver, isExtendedList) => ({
-  //background: isDraggingOver ? 'lightblue' : 'lightgrey',
-  width: '100%',
-  paddingBottom: 20,
-  maxHeight: isExtendedList ? '80vh' : '350px',
-  height: isExtendedList ? '60vh' : '300px',
-})
-
 class Waypoints extends Component {
   static propTypes = {
     directions: PropTypes.object,
@@ -81,20 +73,16 @@ class Waypoints extends Component {
 
   render() {
     const { waypoints } = this.props.directions
-    const isExtendedList = waypoints.length >= 6
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
         <Droppable droppableId="droppable">
           {(provided, snapshot) => (
             <React.Fragment>
               <div
-                className={`flex 
-                ${
-                  isExtendedList ? 'flex-column overflow-auto' : 'flex-column'
-                }`}
+                className="flex flex-column"
                 {...provided.droppableProps}
                 ref={provided.innerRef}
-                style={getListStyle(snapshot.isDraggingOver, isExtendedList)}
+                style={{ minHeight: '22rem' }}
               >
                 {waypoints.map((wp, index) => (
                   <Draggable key={wp.id} draggableId={wp.id} index={index}>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

Closes #123 

## 👨‍💻 Changes proposed

1. Instead of list of waypoints doubling in height at 6+ waypoints, list of waypoints increases per waypoint after 6+.
2. Uses the already existing overflow: auto of the drawer instead of the list of waypoint for scrolling.

## 📄 Note to reviewers

<!-- Add notes to reviewers if applicable -->

Not related to this PR/Issue, should I wait to be assigned to an issue before making a PR? (I am interested in GSoC)

## 📷 Screenshots

<!-- Add any relevant screenshots if applicable -->
![Capture](https://user-images.githubusercontent.com/57111473/225158125-eed9b28c-60b4-4926-aff1-3d318211141f.PNG)

