### PR TITLE
Fix double call to route API on truck profile

### DIFF
--- a/src/Controls/settings-panel.jsx
+++ b/src/Controls/settings-panel.jsx
@@ -130,7 +130,10 @@ class SettingsPanel extends React.Component {
       this.setState({ generalSettings, extraSettings })
     }
 
-    if (!R.equals(settings, nextProps.settings)) {
+    if (
+      R.equals(profile, nextProps.profile) &&
+      !R.equals(settings, nextProps.settings)
+    ) {
       if (activeTab === 0) {
         dispatch(makeRequest())
       } else {


### PR DESCRIPTION
Hi, thanks for this very useful Valhalla web frontend!

## 👨‍💻 Changes proposed

I noticed duplicate calls to route API  from / to the truck profile.
I guessed this only happens with the truck profile because it is the only one one having a different set of default settings.

## 📄 Note to reviewers

I'm not familiar with all the effects / actions in this codebase, so I'm not sure this is the right change, but it fix the issue.

## 📷 Screenshots

Relevant screenshot from https://valhalla.openstreetmap.de/
The first API call is made with the car profile.
I then switched to the truck profile, and two API calls were fired at same time, one of them getting a 429 error (too many requests).

![Screenshot_2023-06-09_11-42-46](https://github.com/gis-ops/valhalla-app/assets/2727378/971593af-2658-4565-81b5-29032bbdeba4)

