### PR TITLE
Fix: reset settings when switching profile on isochrone

### DIFF
--- a/src/Controls/Isochrones/index.js
+++ b/src/Controls/Isochrones/index.js
@@ -13,6 +13,7 @@ import {
   updateProfile,
   doShowSettings,
   updatePermalink,
+  resetSettings,
 } from 'actions/commonActions'
 import { clearIsos, makeIsochronesRequest } from 'actions/isochronesActions'
 
@@ -26,6 +27,7 @@ class IsochronesControl extends React.Component {
   handleUpdateProfile = (event, data) => {
     const { dispatch } = this.props
     dispatch(updateProfile({ profile: data.valhalla_profile }))
+    dispatch(resetSettings())
     dispatch(updatePermalink())
   }
 


### PR DESCRIPTION
Hi, here a little fix for a bug I found recently.

When switching profile on Directions tabs, all settings are reset. This is not the case in Isochrones tabs, which can be an issue when two profiles share some settings (eg car and truck profiles).


## 👨‍💻 Changes proposed

Reset all settings when switching profile in Isochrones, exactly as in Directions

## 📷 Screenshots

Calling an Isochrone with the car profile. `width` is the car default (1.6m).

![Screenshot_2023-11-10_10-34-36](https://github.com/gis-ops/valhalla-app/assets/2727378/10a26a6c-4575-4598-9220-c7e7cd31a7ba)

Switching to the truck profile. `width` is still the car default (1.6m) instead of the truck default (2.6m).

![Screenshot_2023-11-10_10-34-51](https://github.com/gis-ops/valhalla-app/assets/2727378/9f698fbb-df4f-4344-af2d-e630d03d0e19)

