### PR TITLE
fixed button issue

### DIFF
--- a/src/Map/Map.css
+++ b/src/Map/Map.css
@@ -10,3 +10,11 @@
   width: 100%;
   height: 100vh;
 }
+
+@media screen and (max-width: 383px) {
+  #osm-button {
+    /* Adjust the position for smaller screens */
+    bottom: 40px;
+    right: 40px;
+  }
+}


### PR DESCRIPTION
## 🛠️ Fixes Issue

Fixes the position of OSM button for screens below 383px.

## 👨‍💻 Changes proposed

set some rules for max-width: 383px
and added some pixels to bottom

## Code

```
@media screen and (max-width: 383px) {
  #osm-button {
    /* Adjust the position for smaller screens */
    bottom: 40px;
    right: 40px;
  }
}
```

## 📷 Screenshots

before:
![Screenshot 2024-01-09 231504](https://github.com/gis-ops/valhalla-app/assets/40739838/259f10da-45d7-40f8-a588-bed16b12f8ee)

after
![Screenshot 2024-01-09 231145](https://github.com/gis-ops/valhalla-app/assets/40739838/c827fa6e-5015-4c42-aeae-c25e9ec39cef)
