### PR TITLE
Add immer as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "cmdk": "^1.1.1",
         "d3": "^7.9.0",
         "date-fns": "^4.1.0",
+        "immer": "^11.1.3",
         "lucide-react": "^0.562.0",
         "maplibre-gl": "^5.15.0",
         "next-themes": "^0.4.6",
@@ -10788,12 +10789,10 @@
       }
     },
     "node_modules/immer": {
-      "version": "11.0.1",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/immer/-/immer-11.0.1.tgz",
-      "integrity": "sha512-naDCyggtcBWANtIrjQEajhhBEuL9b0Zg4zmlWK2CzS6xCWSE39/vvf4LqnMjUAWHBhot4m9MHCM/Z+mfWhUkiA==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.3.tgz",
+      "integrity": "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "cmdk": "^1.1.1",
     "d3": "^7.9.0",
     "date-fns": "^4.1.0",
+    "immer": "^11.1.3",
     "lucide-react": "^0.562.0",
     "maplibre-gl": "^5.15.0",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
## 🛠️ Fixes Issue

Closes #279

## 👨‍💻 Changes proposed

We are using `zustand/middleware/immer` which is just a wrapper around the `immer` library. This PR adds the `immer` to dependency list.