### PR TITLE
Fallback profile parameter to default profile

### DIFF
--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -9,6 +9,39 @@ test('has title', async ({ page }) => {
   await expect(page).toHaveTitle(/Valhalla FOSSGIS/);
 });
 
+test('should retain profile when switching between tabs', async ({ page }) => {
+  await expect(page.getByTestId('profile-button-bicycle')).toHaveAttribute(
+    'data-state',
+    'on'
+  );
+  expect(page.url()).toContain('profile=bicycle');
+
+  await page.getByTestId('profile-button-car').click();
+  await expect(page.getByTestId('profile-button-car')).toHaveAttribute(
+    'data-state',
+    'on'
+  );
+  expect(page.url()).toContain('profile=car');
+
+  await page.getByTestId('isochrones-tab-button').click();
+
+  await expect(page.getByTestId('profile-button-car')).toHaveAttribute(
+    'data-state',
+    'on'
+  );
+  expect(page.url()).toContain('profile=car');
+  expect(page.url()).toContain('/isochrones');
+
+  await page.getByTestId('directions-tab-button').click();
+
+  await expect(page.getByTestId('profile-button-car')).toHaveAttribute(
+    'data-state',
+    'on'
+  );
+  expect(page.url()).toContain('profile=car');
+  expect(page.url()).toContain('/directions');
+});
+
 test('has default elements in the page', async ({ page }) => {
   await page.goto('http://localhost:3000/');
 

--- a/src/routes.spec.ts
+++ b/src/routes.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { redirect } from '@tanstack/react-router';
+import { isValidTab } from './utils/route-schemas';
+
+function activeTabBeforeLoad({
+  params,
+  search,
+}: {
+  params: { activeTab: string };
+  search: { profile?: string; style?: string };
+}) {
+  if (!isValidTab(params.activeTab)) {
+    throw redirect({
+      to: '/$activeTab',
+      params: { activeTab: 'directions' },
+      search: {
+        profile: 'bicycle',
+      },
+    });
+  }
+  if (!search.profile) {
+    throw redirect({
+      to: '/$activeTab',
+      params: { activeTab: params.activeTab },
+      search: {
+        ...search,
+        profile: 'bicycle',
+      },
+    });
+  }
+}
+
+describe('routes', () => {
+  describe('activeTabRoute beforeLoad', () => {
+    it('should redirect to directions with default profile for invalid tab', () => {
+      expect(() =>
+        activeTabBeforeLoad({
+          params: { activeTab: 'invalid' },
+          search: {},
+        })
+      ).toThrow();
+    });
+
+    it('should redirect with default profile when profile is missing', () => {
+      expect(() =>
+        activeTabBeforeLoad({
+          params: { activeTab: 'directions' },
+          search: {},
+        })
+      ).toThrow();
+    });
+
+    it('should redirect with default profile and preserve other search params', () => {
+      try {
+        activeTabBeforeLoad({
+          params: { activeTab: 'isochrones' },
+          search: { style: 'custom' },
+        });
+      } catch (e) {
+        expect(e).toBeDefined();
+      }
+    });
+
+    it('should not redirect when profile is present', () => {
+      expect(() =>
+        activeTabBeforeLoad({
+          params: { activeTab: 'directions' },
+          search: { profile: 'car' },
+        })
+      ).not.toThrow();
+    });
+
+    it('should not redirect when profile is present on isochrones tab', () => {
+      expect(() =>
+        activeTabBeforeLoad({
+          params: { activeTab: 'isochrones' },
+          search: { profile: 'truck' },
+        })
+      ).not.toThrow();
+    });
+
+    it('should preserve existing profile when switching tabs', () => {
+      expect(() =>
+        activeTabBeforeLoad({
+          params: { activeTab: 'isochrones' },
+          search: { profile: 'car' },
+        })
+      ).not.toThrow();
+
+      expect(() =>
+        activeTabBeforeLoad({
+          params: { activeTab: 'directions' },
+          search: { profile: 'car' },
+        })
+      ).not.toThrow();
+    });
+  });
+});

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -38,12 +38,22 @@ const activeTabRoute = createRoute({
   search: {
     middlewares: [retainSearchParams(['profile', 'style'])],
   },
-  beforeLoad: ({ params }) => {
+  beforeLoad: ({ params, search }) => {
     if (!isValidTab(params.activeTab)) {
       throw redirect({
         to: '/$activeTab',
         params: { activeTab: 'directions' },
         search: {
+          profile: 'bicycle',
+        },
+      });
+    }
+    if (!search.profile) {
+      throw redirect({
+        to: '/$activeTab',
+        params: { activeTab: params.activeTab },
+        search: {
+          ...search,
           profile: 'bicycle',
         },
       });


### PR DESCRIPTION
## 🛠️ Fixes Issue

Closes #284

## 👨‍💻 Changes proposed

- We are using url parameter "profile" as our source of truth while settings the profile. It should be always defined. This PR adds fallback so when there is no profile in the URL, it will use 'bicycle'.
