### PR TITLE
fix: carto base map attribution

### DIFF
--- a/public/styles/carto.json
+++ b/public/styles/carto.json
@@ -7,7 +7,7 @@
       "tileSize": 256,
       "minzoom": 0,
       "maxzoom": 19,
-      "attribution": "© OpenStreetMap contributors"
+      "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors"
     }
   },
   "layers": [


### PR DESCRIPTION
Attribution must be set on the source to be displayed by maplibre (was on the layer).

## 👨‍💻 Changes proposed

Fix OSM attribution for the Carto basemap

## 📷 Screenshots

Before

<img width="300" height="185" alt="Screenshot_2026-01-07_15-27-33" src="https://github.com/user-attachments/assets/9184d7ad-337a-4319-98b0-d863ed2a1a33" />

After

<img width="325" height="239" alt="Screenshot_2026-01-07_15-29-27" src="https://github.com/user-attachments/assets/9f0e7801-7537-4e02-8d52-186d795236e7" />


<!-- Add any relevant screenshots if applicable -->
