### PR TITLE
fix: add github comment to 'about this service' link in attribution

### DIFF
--- a/public/styles/carto.json
+++ b/public/styles/carto.json
@@ -7,7 +7,7 @@
       "tileSize": 256,
       "minzoom": 0,
       "maxzoom": 19,
-      "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors"
+      "attribution": "<a href=\"https://github.com/valhalla/valhalla/discussions/3373#discussion-3655404\" target=\"_blank\">About this service</a> | &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors"
     }
   },
   "layers": [

--- a/public/styles/versatiles-colorful.json
+++ b/public/styles/versatiles-colorful.json
@@ -13,7 +13,7 @@
   ],
   "sources": {
     "versatiles-shortbread": {
-      "attribution": "<a href=\"https://map.project-osrm.org/about.html\" target=\"_blank\">About this service and privacy policy</a> | &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+      "attribution": "<a href=\"https://github.com/valhalla/valhalla/discussions/3373#discussion-3655404\" target=\"_blank\">About this service</a> | &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
       "tiles": [
         "https://vector.openstreetmap.org/shortbread_v1/{z}/{x}/{y}.mvt"
       ],


### PR DESCRIPTION
## 👨‍💻 Changes proposed

for the shortbread tiles we were linking to OSRM's "About" page. I changed that to this github comment where we introduce the service: https://github.com/valhalla/valhalla/discussions/3373

