### PR TITLE
remove units for non-speed live traffic properties in tile popup

### DIFF
--- a/src/components/map/parts/tiles-property.spec.tsx
+++ b/src/components/map/parts/tiles-property.spec.tsx
@@ -164,6 +164,19 @@ describe('TilesProperty', () => {
     });
   });
 
+  describe('live traffic breakpoints and congestion', () => {
+    it('should show speed without km/h unit', () => {
+      render(
+        <TilesProperty
+          propertyKey="live_traffic:forward:congestion0"
+          value={50}
+        />
+      );
+      expect(screen.getByText('50')).toBeInTheDocument();
+      expect(screen.queryByText('km/h')).not.toBeInTheDocument();
+    });
+  });
+
   describe('slope values', () => {
     it('should show slope with degree unit', () => {
       render(<TilesProperty propertyKey="max_up_slope" value={5} />);

--- a/src/components/map/parts/tiles-property.tsx
+++ b/src/components/map/parts/tiles-property.tsx
@@ -88,7 +88,10 @@ export function TilesProperty({
     );
   }
 
-  if (propertyKey.includes('speed')) {
+  if (
+    propertyKey.includes('speed') &&
+    !(propertyKey.includes('congestion') || propertyKey.includes('breakpoint'))
+  ) {
     return (
       <span className="font-mono text-xs">
         {String(value)}


### PR DESCRIPTION
# Before 
<img width="482" height="376" alt="Screenshot From 2026-01-28 18-10-36" src="https://github.com/user-attachments/assets/781dfc39-f2e4-46ac-b32f-692ab3aeb0c8" />

# After
<img width="482" height="376" alt="Screenshot From 2026-01-28 18-10-53" src="https://github.com/user-attachments/assets/7021fc03-2ef0-44fb-ba59-714ed9e0e1d0" />
