### PR TITLE
feat : Added Colorblind-Friendly Color Palettes and Opacity Control for Isochrones

### DIFF
--- a/src/components/isochrones/waypoints.tsx
+++ b/src/components/isochrones/waypoints.tsx
@@ -25,10 +25,23 @@ import { AccessibleIcon } from '@radix-ui/react-accessible-icon';
 import { parseUrlParams } from '@/utils/parse-url-params';
 import { useNavigate } from '@tanstack/react-router';
 import { useIsochronesQuery } from '@/hooks/use-isochrones-queries';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { ISOCHRONE_PALETTES } from '@/utils/isochrone-colors';
 
 export const Waypoints = () => {
   const params = parseUrlParams();
   const updateSettings = useIsochronesStore((state) => state.updateSettings);
+  const updateColorPalette = useIsochronesStore(
+    (state) => state.updateColorPalette
+  );
+  const updateOpacity = useIsochronesStore((state) => state.updateOpacity);
   const { refetch: refetchIsochrones } = useIsochronesQuery();
   const clearIsos = useIsochronesStore((state) => state.clearIsos);
   const updateTextInput = useIsochronesStore((state) => state.updateTextInput);
@@ -36,6 +49,8 @@ export const Waypoints = () => {
   const interval = useIsochronesStore((state) => state.interval);
   const denoise = useIsochronesStore((state) => state.denoise);
   const generalize = useIsochronesStore((state) => state.generalize);
+  const colorPalette = useIsochronesStore((state) => state.colorPalette);
+  const opacity = useIsochronesStore((state) => state.opacity);
   const navigate = useNavigate({ from: '/$activeTab' });
   const userInput = useIsochronesStore((state) => state.userInput);
   const geocodeResults = useIsochronesStore((state) => state.geocodeResults);
@@ -235,6 +250,42 @@ export const Waypoints = () => {
               const validValue = isNaN(value) ? settingsInit.generalize : value;
               updateSettings({ name: 'generalize', value: validValue });
               makeIsochronesRequestDebounced();
+            }}
+          />
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="color-palette" className="text-sm font-medium">
+              Color Palette
+            </Label>
+            <Select value={colorPalette} onValueChange={updateColorPalette}>
+              <SelectTrigger id="color-palette">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(ISOCHRONE_PALETTES).map(([key, option]) => (
+                  <SelectItem key={key} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <SliderSetting
+            id="opacity"
+            label="Opacity"
+            description="The opacity of the isochrone visualization (0 = transparent, 1 = fully opaque)"
+            min={0}
+            max={1}
+            step={0.1}
+            value={opacity}
+            onValueChange={(values) => {
+              const value = values[0] ?? 0.4;
+              updateOpacity(value);
+            }}
+            onInputChange={(values) => {
+              const value = values[0] ?? 0.4;
+              updateOpacity(value);
             }}
           />
         </CollapsibleContent>

--- a/src/components/map/parts/isochrone-polygons.spec.tsx
+++ b/src/components/map/parts/isochrone-polygons.spec.tsx
@@ -42,13 +42,16 @@ const createMockState = (overrides = {}) => ({
               ],
             ],
           },
-          properties: { fill: '#ff0000' },
+          properties: { fill: '#ff0000', contour: 10 },
         },
       ],
     },
     show: true,
   },
   successful: true,
+    colorPalette: 'current',
+    opacity: 0.4,
+    maxRange: 10,
   ...overrides,
 });
 
@@ -130,7 +133,7 @@ describe('IsochronePolygons', () => {
       expect.objectContaining({
         id: 'isochrones-fill',
         type: 'fill',
-        paint: { 'fill-color': ['get', 'fill'], 'fill-opacity': 0.4 },
+        paint: { 'fill-color': ['get', 'fillColor'], 'fill-opacity': 0.4 },
       })
     );
   });
@@ -162,7 +165,7 @@ describe('IsochronePolygons', () => {
               {
                 type: 'Feature',
                 geometry: { type: 'Polygon', coordinates: [] },
-                properties: { fill: '#ff0000' },
+                properties: { fill: '#ff0000', contour: 10 },
               },
               {
                 type: 'Feature',
@@ -174,6 +177,9 @@ describe('IsochronePolygons', () => {
           show: true,
         },
         successful: true,
+        colorPalette: 'current',
+        opacity: 0.4,
+        maxRange: 10,
       };
       return selector(state);
     });

--- a/src/components/map/parts/isochrone-polygons.tsx
+++ b/src/components/map/parts/isochrone-polygons.tsx
@@ -2,10 +2,14 @@ import { useMemo } from 'react';
 import { Source, Layer } from 'react-map-gl/maplibre';
 import { useIsochronesStore } from '@/stores/isochrones-store';
 import type { Feature, FeatureCollection } from 'geojson';
+import { getIsochroneColor } from '@/utils/isochrone-colors';
 
 export function IsochronePolygons() {
   const isoResults = useIsochronesStore((state) => state.results);
   const isoSuccessful = useIsochronesStore((state) => state.successful);
+  const colorPalette = useIsochronesStore((state) => state.colorPalette);
+  const opacity = useIsochronesStore((state) => state.opacity);
+  const maxRange = useIsochronesStore((state) => state.maxRange);
 
   const data = useMemo(() => {
     if (!isoResults || !isoSuccessful) return null;
@@ -18,11 +22,22 @@ export function IsochronePolygons() {
 
     for (const feature of isoResults.data.features) {
       if (['Polygon', 'MultiPolygon'].includes(feature.geometry.type)) {
+        const contourValue = feature.properties?.contour || maxRange;
+        let fillColor: string;
+        
+        if (colorPalette === 'current') {
+          fillColor = feature.properties?.fill || '#6200ea';
+        } else {
+          const normalizedValue = contourValue / maxRange;
+          fillColor = getIsochroneColor(normalizedValue, colorPalette);
+        }
+
         features.push({
           ...feature,
           properties: {
             ...feature.properties,
-            fillColor: feature.properties?.fill || '#6200ea',
+            fillColor,
+            contourValue,
           },
         });
       }
@@ -32,7 +47,7 @@ export function IsochronePolygons() {
       type: 'FeatureCollection',
       features,
     } as FeatureCollection;
-  }, [isoResults, isoSuccessful]);
+  }, [isoResults, isoSuccessful, colorPalette, maxRange]);
 
   if (!data) return null;
 
@@ -42,8 +57,8 @@ export function IsochronePolygons() {
         id="isochrones-fill"
         type="fill"
         paint={{
-          'fill-color': ['get', 'fill'],
-          'fill-opacity': 0.4,
+          'fill-color': ['get', 'fillColor'],
+          'fill-opacity': opacity,
         }}
       />
       <Layer

--- a/src/stores/isochrones-store.ts
+++ b/src/stores/isochrones-store.ts
@@ -5,6 +5,7 @@ import type {
   ActiveWaypoint,
   ValhallaIsochroneResponse,
 } from '@/components/types';
+import type { IsochronePalette } from '@/utils/isochrone-colors';
 
 interface IsochroneResult {
   data: ValhallaIsochroneResponse | null;
@@ -20,6 +21,8 @@ interface IsochroneState {
   interval: number;
   denoise: number;
   generalize: number;
+  colorPalette: IsochronePalette;
+  opacity: number;
   results: IsochroneResult;
 }
 
@@ -34,6 +37,8 @@ interface IsochroneActions {
     name: 'maxRange' | 'interval' | 'denoise' | 'generalize';
     value: number;
   }) => void;
+  updateColorPalette: (palette: IsochronePalette) => void;
+  updateOpacity: (opacity: number) => void;
   receiveGeocodeResults: (addresses: ActiveWaypoint[]) => void;
 }
 
@@ -50,6 +55,8 @@ export const useIsochronesStore = create<IsochroneStore>()(
       interval: 10,
       denoise: 0.1,
       generalize: 0,
+      colorPalette: 'current' as IsochronePalette,
+      opacity: 0.4,
       results: { data: null, show: true },
 
       clearIsos: () =>
@@ -101,6 +108,24 @@ export const useIsochronesStore = create<IsochroneStore>()(
           },
           undefined,
           'updateSettings'
+        ),
+
+      updateColorPalette: (palette) =>
+        set(
+          (state) => {
+            state.colorPalette = palette;
+          },
+          undefined,
+          'updateColorPalette'
+        ),
+
+      updateOpacity: (opacity) =>
+        set(
+          (state) => {
+            state.opacity = Math.max(0, Math.min(1, opacity));
+          },
+          undefined,
+          'updateOpacity'
         ),
 
       receiveGeocodeResults: (addresses) =>

--- a/src/utils/isochrone-colors.ts
+++ b/src/utils/isochrone-colors.ts
@@ -1,0 +1,193 @@
+type ColorPalette = 'viridis' | 'current' | 'magma';
+
+interface RGBColor {
+  r: number;
+  g: number;
+  b: number;
+}
+
+function getViridisColor(value: number): string {
+  //to keep value between 0 annd 1
+  const v = Math.max(0, Math.min(1, value));
+
+  // Simplifying viridis palette with 5 key stops
+  const colors: [number, string][] = [
+    [0.0, '#440154'], // dark purple
+    [0.25, '#31688e'], // blue
+    [0.5, '#35b779'], // green
+    [0.75, '#fde724'], // yellow
+    [1.0, '#fde724'], // yellow
+  ];
+
+  
+  let lower: [number, string] = colors[0]!;
+  let upper: [number, string] = colors[colors.length - 1]!;
+
+  for (let i = 0; i < colors.length - 1; i++) {
+    const current = colors[i];
+    const next = colors[i + 1];
+    if (current && next && v >= current[0] && v <= next[0]) {
+      lower = current;
+      upper = next;
+      break;
+    }
+  }
+
+  const range = upper[0] - lower[0];
+  const t = range === 0 ? 0 : (v - lower[0]) / range;
+
+  const color1 = hexToRgb(lower[1]);
+  const color2 = hexToRgb(upper[1]);
+
+  const r = Math.round(color1.r + (color2.r - color1.r) * t);
+  const g = Math.round(color1.g + (color2.g - color1.g) * t);
+  const b = Math.round(color1.b + (color2.b - color1.b) * t);
+
+  return rgbToHex(r, g, b);
+}
+
+function getCurrentColor(value: number): string {
+  const v = Math.max(0, Math.min(1, value));
+
+
+  const colors: [number, string][] = [
+    [0.0, '#00ff00'], // green
+    [0.33, '#ffff00'], // yellow
+    [0.66, '#ff8800'], // orange
+    [1.0, '#ff0000'], // red
+  ];
+
+  let lower: [number, string] = colors[0]!;
+  let upper: [number, string] = colors[colors.length - 1]!;
+
+  for (let i = 0; i < colors.length - 1; i++) {
+    const current = colors[i];
+    const next = colors[i + 1];
+    if (current && next && v >= current[0] && v <= next[0]) {
+      lower = current;
+      upper = next;
+      break;
+    }
+  }
+
+  const range = upper[0] - lower[0];
+  const t = range === 0 ? 0 : (v - lower[0]) / range;
+
+  const color1 = hexToRgb(lower[1]);
+  const color2 = hexToRgb(upper[1]);
+
+  const r = Math.round(color1.r + (color2.r - color1.r) * t);
+  const g = Math.round(color1.g + (color2.g - color1.g) * t);
+  const b = Math.round(color1.b + (color2.b - color1.b) * t);
+
+  return rgbToHex(r, g, b);
+}
+
+/**
+ * Magma color palette - perceptually uniform, colorblind friendly
+ * Maps value 0-1 to colors: yellow -> orange -> pink -> purple -> dark
+ */
+function getMagmaColor(value: number): string {
+  const v = Math.max(0, Math.min(1, value));
+
+  // Magma palette: yellow -> orange -> pink -> purple -> almost black
+  const colors: [number, string][] = [
+    [0.0, '#fcfdbf'], // light yellow
+    [0.25, '#fc8961'], // orange
+    [0.5, '#b73779'], // magenta/pink
+    [0.75, '#51127c'], // purple
+    [1.0, '#000004'], // almost black
+  ];
+
+  let lower: [number, string] = colors[0]!;
+  let upper: [number, string] = colors[colors.length - 1]!;
+
+  for (let i = 0; i < colors.length - 1; i++) {
+    const current = colors[i];
+    const next = colors[i + 1];
+    if (current && next && v >= current[0] && v <= next[0]) {
+      lower = current;
+      upper = next;
+      break;
+    }
+  }
+
+  const range = upper[0] - lower[0];
+  const t = range === 0 ? 0 : (v - lower[0]) / range;
+
+  const color1 = hexToRgb(lower[1]);
+  const color2 = hexToRgb(upper[1]);
+
+  const r = Math.round(color1.r + (color2.r - color1.r) * t);
+  const g = Math.round(color1.g + (color2.g - color1.g) * t);
+  const b = Math.round(color1.b + (color2.b - color1.b) * t);
+
+  return rgbToHex(r, g, b);
+}
+
+/**
+ * Get color for a value (0-1) based on selected palette
+ * @param value - Number between 0 and 1 (0 = closest/easiest, 1 = farthest/hardest)
+ * @param palette - Selected color palette
+ * @returns Hex color string
+ */
+export function getIsochroneColor(
+  value: number,
+  palette: ColorPalette = 'current'
+): string {
+  switch (palette) {
+    case 'viridis':
+      return getViridisColor(value);
+    case 'current':
+      return getCurrentColor(value);
+        case 'magma':
+          return getMagmaColor(value);
+    default:
+      return getCurrentColor(value);
+  }
+}
+
+/**
+ * Convert hex color to RGB
+ */
+function hexToRgb(hex: string): RGBColor {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return {
+    r: parseInt(result?.[1] || '0', 16),
+    g: parseInt(result?.[2] || '0', 16),
+    b: parseInt(result?.[3] || '0', 16),
+  };
+}
+
+/**
+ * Convert RGB to hex color
+ */
+function rgbToHex(r: number, g: number, b: number): string {
+  return (
+    '#' +
+    [r, g, b]
+      .map((x) => {
+        const hex = x.toString(16);
+        return hex.length === 1 ? '0' + hex : hex;
+      })
+      .join('')
+  );
+}
+
+export const ISOCHRONE_PALETTES = {
+     current: {
+    label: 'Default',
+    value: 'current' as const,
+  },
+    magma: {
+      label: 'Magma (colorblind-friendly)',
+      value: 'magma' as const,
+    },
+  viridis: {
+    label: 'Viridis (colorblind-friendly)',
+    value: 'viridis' as const,
+  },
+  
+} as const;
+
+export type IsochronePalette = keyof typeof ISOCHRONE_PALETTES;


### PR DESCRIPTION
Closes #283
Addresses isochrone color customization issue

## 🛠️ Fixes Issue

The current isochrone visualization uses a red-green color gradient that is not accessible for colorblind users. Additionally, the colors are too opaque, making it difficult to see the underlying map features.

## 👨‍💻 Changes proposed

This PR implements:

### 1. Colorblind-Friendly Color Palettes

-  **Viridis** (Colourblind-Friendly) : A perceptually uniform gradient ranging from dark purple through blue and green to yellow.  
-  **Magma**(Colourblind-Friendly): A high-contrast gradient progressing from light yellow through orange and pink to deep purple and black.  
-  **Deafult**: Ensures no disruption for users familiar with the previous styling

### 2. Opacity Control

- User-adjustable slider (0.0 - 1.0)
- Default: 0.4 (40% opacity)
- Improves map readability by allowing base map to show through

### 3. Intuitive UI

- Controls placed in **Isochrones Settings** panel
- Color Palette dropdown selector
- Opacity slider with real-time preview

## Technical Implementation

### New Files

- `src/utils/isochrone-colors.ts` - Color palette utilities with interpolation functions

### Modified Files

- `src/stores/isochrones-store.ts` - Added `colorPalette` and `opacity` state
- `src/components/isochrones/waypoints.tsx` - Added UI controls
- `src/components/map/parts/isochrone-polygons.tsx` - Dynamic color application
- `src/components/map/parts/isochrone-polygons.spec.tsx` - Changed according to the additional store state

## Testing

- [x] Opacity slider updates visualization in real-time
- [x] Build compilation passes with no errors
- [x] Updated isochrone-polygons tests to include contour-based mock data and new store fields

## 📷 Screenshots

<img width="1474" height="838" alt="Screenshot 2026-03-04 192628" src="https://github.com/user-attachments/assets/bb994701-365e-4980-93d2-4e1f7136f352" />
