### PR TITLE
fix: height graph renders correctly when reopened

### DIFF
--- a/src/components/heightgraph.tsx
+++ b/src/components/heightgraph.tsx
@@ -239,7 +239,7 @@ const HeightGraph: React.FC<HeightGraphProps> = ({
     return () => {
       tooltip.remove();
     };
-  }, [data, dimensions, onHighlight]);
+  }, [data, dimensions, onHighlight, isExpanded]);
 
   const [prevProps, setPrevProps] = useState({ width, height });
   if (prevProps.width !== width || prevProps.height !== height) {


### PR DESCRIPTION
### Fixes Issue

Closes #348

### What's the problem?

The height graph shows up fine the first time you open it, but if you close it and reopen it, you just get a blank SVG with the legend at the bottom.

### Why does this happen?

When you close the graph, React unmounts the SVG element. When you open it again, a fresh SVG gets mounted, but the D3 drawing code doesn't run because the useEffect dependencies haven't changed.

The useEffect was watching `[data, dimensions, onHighlight]`, so React thinks "nothing changed, skip the effect". But the SVG element itself is brand new and needs to be drawn on.

### The fix

Added `isExpanded` to the dependency array:

```diff
-  }, [data, dimensions, onHighlight]);
+  }, [data, dimensions, onHighlight, isExpanded]);
```

Now when `isExpanded` changes from `false` → `true`, React re-runs the effect and draws the graph.

### Testing

- Open height graph → works
- Close and reopen → works now
- Repeat multiple times → keeps working

---

**Note:** This PR description was written with assistance from AI tool. The code changes and bug investigation were done by me, and I've verified the fix works as expected.
