### PR TITLE
Fix: prevent duplicate waypoint creation when reopening sidebar

### DIFF
--- a/src/hooks/use-directions-queries.ts
+++ b/src/hooks/use-directions-queries.ts
@@ -150,7 +150,11 @@ export function useReverseGeocodeDirections() {
     options?: { isPermalink?: boolean }
   ) => {
     // For permalink loading, add waypoint if needed
-    if (options?.isPermalink && index > 1) {
+    if (
+      options?.isPermalink &&
+      index > 1 &&
+      useDirectionsStore.getState().waypoints.length <= index
+    ) {
       addEmptyWaypointToEnd();
     }
 


### PR DESCRIPTION
## 🛠️ Fixes Issue

Closes #365 

## 👨‍💻 Changes proposed

* Prevent extra waypoint from being added when reopening the sidebar.
* Added a guard condition before calling `addEmptyWaypointToEnd()`.

## 📍 Where the change was made

* **File:** `src/hooks/use-directions-queries.ts`
* **Function:** `reverseGeocode()`
* Updated the condition to ensure a waypoint is only added if it doesn't already exist.

## 📄 Note to reviewers

Tested by adding multiple waypoints and reopening the sidebar; no duplicate waypoints appear.

## 📷 Screenshots

Explore Video of Fix:

https://github.com/user-attachments/assets/f5ba610f-b755-4ee5-94af-5c819d3f41e7


