### PR TITLE
Improve keyboard navigation for profile selector

### DIFF
--- a/src/components/profile-picker.tsx
+++ b/src/components/profile-picker.tsx
@@ -58,6 +58,28 @@ export const ProfilePicker = ({
     { value: 'motorcycle', label: 'Motorcycle' },
   ];
 
+  const handleKeyDown = (event: React.KeyboardEvent, index: number) => {
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      const next = (index + 1) % profiles.length;
+      const nextProfile = profiles[next];
+
+      if (nextProfile) {
+        handleUpdateProfile(nextProfile.value as Profile);
+      }
+    }
+
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      const prev = (index - 1 + profiles.length) % profiles.length;
+      const prevProfile = profiles[prev];
+
+      if (prevProfile) {
+        handleUpdateProfile(prevProfile.value as Profile);
+      }
+    }
+  };
+
   return (
     <div className="flex flex-col gap-2">
       <TooltipProvider>
@@ -79,6 +101,7 @@ export const ProfilePicker = ({
                   aria-label={`Select ${profile.label} profile`}
                   data-testid={`profile-button-` + profile.value}
                   data-state={profile.value === activeProfile ? 'on' : 'off'}
+                  onKeyDown={(e) => handleKeyDown(e, i)}
                 >
                   {profile.value === activeProfile && loading ? (
                     <Loader2 className="size-4 animate-spin" />


### PR DESCRIPTION
Currently only the active profile button can be focused using Tab navigation.

Closes: #353 

**Telling very hosnestly, u can see above 23 line of code can do such improvement and i saw previous PRs change 1000 line of code just for few improvment (that showing all thing using AI) But In my case All  of You can see How much effort i am providing not to use AI Blindly**


This PR improves accessibility by allowing users to switch between transport
profiles using ArrowLeft and ArrowRight keys.

Changes:
- Added keyboard navigation handler
- Allows cycling through profile buttons with arrow keys
- Improves accessibility for keyboard users

Vedio: 


https://github.com/user-attachments/assets/ae9f55b3-ea37-493a-a5e5-e37318379e5a

