### PR TITLE
Fix elevation profile not updating when route changes

### DIFF
--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -347,6 +347,10 @@ export const MapComponent = () => {
     }
   }, [directionResults, heightPayload, updateInclineDecline]);
 
+  useEffect(() => {
+    getHeightData();
+  }, [getHeightData]);
+
   // Update markers when waypoints or isochrone centers change
   const geocodeResults = useIsochronesStore((state) => state.geocodeResults);
   const markers = useMemo(() => {


### PR DESCRIPTION
## Summary
- The height graph data was only fetched when the HeightGraph drawer was expanded/collapsed via `onExpand`
- Added a `useEffect` that automatically fetches height data whenever `directionResults` changes
- The existing `JSON.stringify` comparison prevents duplicate `/height` API calls

## Test plan
- [x] Set two waypoints and get a route with elevation profile
- [x] Drag a waypoint to change the route — elevation profile updates automatically without needing to close/reopen the drawer
- [x] No duplicate `/height` API calls when route hasn't changed
- [x] Existing tests pass (8 pre-existing failures unrelated to this change)