### PR TITLE
fix: updated UI logic for waypoints buttons

### DIFF
--- a/src/components/directions/directions.tsx
+++ b/src/components/directions/directions.tsx
@@ -14,10 +14,7 @@ import { RouteCard } from './route-card';
 import { parseUrlParams } from '@/utils/parse-url-params';
 import { isValidCoordinates } from '@/utils/geom';
 import { useNavigate } from '@tanstack/react-router';
-import {
-  defaultWaypoints,
-  useDirectionsStore,
-} from '@/stores/directions-store';
+import { useDirectionsStore } from '@/stores/directions-store';
 import {
   useDirectionsQuery,
   useReverseGeocodeDirections,
@@ -139,7 +136,7 @@ export const DirectionsControl = () => {
             data-testid="reset-waypoints-button"
             className="w-full shrink"
             disabled={
-              JSON.stringify(waypoints) === JSON.stringify(defaultWaypoints)
+              waypoints.length < 3 && waypoints.every((wp) => !wp.userInput)
             }
           >
             <MapPinXInside className="size-5" />

--- a/src/components/directions/waypoints/waypoint-item.tsx
+++ b/src/components/directions/waypoints/waypoint-item.tsx
@@ -11,10 +11,7 @@ import {
 } from '@/components/ui/tooltip';
 import { WaypointSearch } from '@/components/ui/waypoint-search';
 import { GripVertical, Trash } from 'lucide-react';
-import {
-  defaultWaypoints,
-  useDirectionsStore,
-} from '@/stores/directions-store';
+import { useDirectionsStore } from '@/stores/directions-store';
 import { useDirectionsQuery } from '@/hooks/use-directions-queries';
 
 interface WaypointProps {
@@ -117,7 +114,7 @@ export const Waypoint = ({ id, index }: WaypointProps) => {
                 }}
                 data-testid="remove-waypoint-button"
                 disabled={
-                  JSON.stringify(waypoints) === JSON.stringify(defaultWaypoints)
+                  waypoints.length < 3 && waypoints.every((wp) => !wp.userInput)
                 }
               >
                 <Trash className="size-3" />


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

Bug: Shuffling the waypoints enables the delete and reset waypoint buttons, though no location is added to the waypoints.

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

Closes #382 

## 👨‍💻 Changes proposed

- got rid of the logic of comparing waypoints with defaultWaypoints via JSON. stringify (as shuffling was breaking it).
- those button will only be enabled if 
  - There are more than 2 waypoints (even if empty).
  - There is a location selected in any waypoint.

<!-- List all the proposed changes in your PR -->

## 📄 Note to reviewers
Let me know if you wanted the logic to be any different from this.
I thought I should keep the reset button enabled even on empty waypoints, as deleting every empty waypoint to do a fresh start could be time-consuming, whereas one can just click reset.
<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots

https://github.com/user-attachments/assets/87ad116b-44d6-453f-8a6e-dfdd3ed6a521


<!-- Add any relevant screenshots if applicable -->
