### PR TITLE
feat: permalink with costing options

### DIFF
--- a/e2e/costing-permalink.spec.ts
+++ b/e2e/costing-permalink.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const BASE_URL = 'http://localhost:3000';
+
+async function openSettingsPanel(page: Page) {
+  await page.getByTestId('tab-directions-button').click();
+  await page.getByTestId('show-hide-settings-btn').click();
+  // wait for the settings panel content to be visible
+  await expect(
+    page.getByRole('checkbox', { name: 'Shortest', exact: true })
+  ).toBeVisible();
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(`${BASE_URL}/directions?profile=car`);
+  await openSettingsPanel(page);
+});
+
+test('costing options appear in URL when a setting is changed', async ({
+  page,
+}) => {
+  await page.getByRole('checkbox', { name: 'Shortest', exact: true }).click();
+
+  await expect(page).toHaveURL(/costing=/);
+  const url = new URL(page.url());
+  const costing = JSON.parse(
+    decodeURIComponent(url.searchParams.get('costing')!)
+  );
+  // costing is stored as a plain object in the URL (not double-encoded)
+  expect(costing).toHaveProperty('shortest', true);
+});
+
+test('costing options persist after page refresh', async ({ page }) => {
+  await page.getByRole('checkbox', { name: 'Shortest', exact: true }).click();
+  await expect(page).toHaveURL(/costing=/);
+
+  await page.reload();
+  await openSettingsPanel(page);
+
+  await expect(
+    page.getByRole('checkbox', { name: 'Shortest', exact: true })
+  ).toBeChecked();
+  await expect(page).toHaveURL(/costing=/);
+});
+
+test('costing param is removed from URL when settings are reset to defaults', async ({
+  page,
+}) => {
+  await page.getByRole('checkbox', { name: 'Shortest', exact: true }).click();
+  await expect(page).toHaveURL(/costing=/);
+
+  await page.getByRole('button', { name: 'Reset', exact: true }).last().click();
+
+  await expect(page).not.toHaveURL(/costing=/);
+  await expect(
+    page.getByRole('checkbox', { name: 'Shortest', exact: true })
+  ).not.toBeChecked();
+});
+
+test('costing param is cleared when switching profiles', async ({ page }) => {
+  await page.getByRole('checkbox', { name: 'Shortest', exact: true }).click();
+  await expect(page).toHaveURL(/costing=/);
+
+  await page.getByTestId('close-settings-button').click();
+  await page.getByTestId('profile-button-bicycle').click();
+
+  await expect(page).not.toHaveURL(/costing=/);
+});
+
+test('page loads correctly with costing options in URL', async ({ page }) => {
+  // costing is a plain JSON object in the URL (TanStack Router serializes objects natively)
+  const costing = encodeURIComponent(JSON.stringify({ shortest: true }));
+  await page.goto(`${BASE_URL}/directions?profile=car&costing=${costing}`);
+  await openSettingsPanel(page);
+
+  await expect(
+    page.getByRole('checkbox', { name: 'Shortest', exact: true })
+  ).toBeChecked();
+});
+
+test('page loads correctly with invalid costing param in URL', async ({
+  page,
+}) => {
+  // An invalid (non-object) costing param is ignored by the fallback; page loads normally
+  await page.goto(`${BASE_URL}/directions?profile=car&costing=not-valid-json`);
+  await openSettingsPanel(page);
+
+  await expect(
+    page.getByRole('checkbox', { name: 'Shortest', exact: true })
+  ).not.toBeChecked();
+});

--- a/src/components/route-planner.tsx
+++ b/src/components/route-planner.tsx
@@ -75,7 +75,7 @@ export const RoutePlanner = () => {
 
   const handleProfileChange = (value: Profile) => {
     navigate({
-      search: (prev) => ({ ...prev, profile: value }),
+      search: (prev) => ({ ...prev, profile: value, costing: undefined }),
       replace: true,
     });
 

--- a/src/components/settings-panel/settings-panel.spec.tsx
+++ b/src/components/settings-panel/settings-panel.spec.tsx
@@ -32,10 +32,12 @@ const mockRefetchIsochrones = vi.fn();
 
 const mockUseParams = vi.fn(() => ({ activeTab: 'directions' }));
 const mockUseSearch = vi.fn(() => ({ profile: 'bicycle' }));
+const mockNavigate = vi.fn();
 
 vi.mock('@tanstack/react-router', () => ({
   useParams: () => mockUseParams(),
   useSearch: () => mockUseSearch(),
+  useNavigate: () => mockNavigate,
 }));
 
 vi.mock('@/stores/common-store', () => ({

--- a/src/components/settings-panel/settings-panel.tsx
+++ b/src/components/settings-panel/settings-panel.tsx
@@ -35,6 +35,7 @@ import {
 import { useParams, useSearch } from '@tanstack/react-router';
 import { useDirectionsQuery } from '@/hooks/use-directions-queries';
 import { useIsochronesQuery } from '@/hooks/use-isochrones-queries';
+import { useSettingsUrlSync } from '@/hooks/use-settings-url-sync';
 import { CollapsibleSection } from '@/components/ui/collapsible-section';
 import { ServerSettings } from '@/components/settings-panel/server-settings';
 import { MultiSelectSetting } from '../ui/multiselect-setting';
@@ -52,6 +53,8 @@ export const SettingsPanel = () => {
   const [copied, setCopied] = useState(false);
   const { refetch: refetchDirections } = useDirectionsQuery();
   const { refetch: refetchIsochrones } = useIsochronesQuery();
+
+  useSettingsUrlSync();
 
   const [language, setLanguage] = useState<DirectionsLanguage>(() =>
     getDirectionsLanguage()

--- a/src/hooks/use-settings-url-sync.ts
+++ b/src/hooks/use-settings-url-sync.ts
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useCommonStore, type Profile } from '@/stores/common-store';
+import type { PossibleSettings } from '@/components/types';
+import {
+  serializeCostingOptions,
+  deserializeCostingOptions,
+} from '@/utils/costing-url';
+
+// flow-
+// on mount-use the existing params and apply to settings
+// on change in setting we keep the url in sync
+export function useSettingsUrlSync() {
+  const settings = useCommonStore((state) => state.settings);
+  const updateSettings = useCommonStore((state) => state.updateSettings);
+  const { profile, costing: urlCosting } = useSearch({ from: '/$activeTab' });
+  const navigate = useNavigate({ from: '/$activeTab' });
+
+  // for the initial costing value from the URL before any effects run
+  const initialCostingRef = useRef(urlCosting);
+  const initializedRef = useRef(false);
+
+  useEffect(() => {
+    const costingOptions = deserializeCostingOptions(initialCostingRef.current);
+    for (const [key, value] of Object.entries(costingOptions)) {
+      updateSettings(
+        key as keyof PossibleSettings,
+        value as PossibleSettings[keyof PossibleSettings]
+      );
+    }
+    initializedRef.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!initializedRef.current) return;
+
+    const costing = serializeCostingOptions(
+      settings,
+      (profile || 'bicycle') as Profile
+    );
+    navigate({
+      search: (prev) => ({ ...prev, costing }),
+      replace: true,
+    });
+  }, [settings, profile, navigate]);
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -40,7 +40,7 @@ const activeTabRoute = createRoute({
   component: App,
   validateSearch: zodValidator(searchParamsSchema),
   search: {
-    middlewares: [retainSearchParams(['profile', 'style'])],
+    middlewares: [retainSearchParams(['profile', 'style', 'costing'])],
   },
   beforeLoad: ({ params, search }) => {
     if (!isValidTab(params.activeTab)) {

--- a/src/utils/costing-url.ts
+++ b/src/utils/costing-url.ts
@@ -12,12 +12,12 @@ function getDefaultSettings(profile: Profile): typeof settingsInit {
   return profile === 'truck' ? settingsInitTruckOverride : settingsInit;
 }
 
-// syncs only the non-default costing options to a json string for use in the url
+// syncs only the non-default costing options to an object for use in the url
 // returns undefined if all settings are at their defaults.
 export function serializeCostingOptions(
   settings: PossibleSettings,
   profile: Profile
-): string | undefined {
+): Record<string, unknown> | undefined {
   const defaults = getDefaultSettings(profile) as PossibleSettings;
   const nonDefault: Record<string, unknown> = {};
 
@@ -33,26 +33,15 @@ export function serializeCostingOptions(
   }
 
   if (Object.keys(nonDefault).length === 0) return undefined;
-  return JSON.stringify(nonDefault);
+  return nonDefault;
 }
 
-// for json parsing
-// if sting is invalid it should return empty obj
+// if the costing param is not a plain object, return empty obj
 export function deserializeCostingOptions(
-  costing: string | undefined
+  costing: Record<string, unknown> | undefined
 ): Partial<PossibleSettings> {
-  if (!costing) return {};
-  try {
-    const parsed: unknown = JSON.parse(costing);
-    if (
-      typeof parsed !== 'object' ||
-      parsed === null ||
-      Array.isArray(parsed)
-    ) {
-      return {};
-    }
-    return parsed as Partial<PossibleSettings>;
-  } catch {
+  if (!costing || typeof costing !== 'object' || Array.isArray(costing)) {
     return {};
   }
+  return costing as Partial<PossibleSettings>;
 }

--- a/src/utils/costing-url.ts
+++ b/src/utils/costing-url.ts
@@ -1,0 +1,58 @@
+import {
+  settingsInit,
+  settingsInitTruckOverride,
+} from '@/components/settings-panel/settings-options';
+import type { PossibleSettings } from '@/components/types';
+import type { Profile } from '@/stores/common-store';
+
+// Keys too large to serialize in the URL
+const EXCLUDED_KEYS = new Set<keyof PossibleSettings>(['exclude_polygons']);
+
+function getDefaultSettings(profile: Profile): typeof settingsInit {
+  return profile === 'truck' ? settingsInitTruckOverride : settingsInit;
+}
+
+// syncs only the non-default costing options to a json string for use in the url
+// returns undefined if all settings are at their defaults.
+export function serializeCostingOptions(
+  settings: PossibleSettings,
+  profile: Profile
+): string | undefined {
+  const defaults = getDefaultSettings(profile) as PossibleSettings;
+  const nonDefault: Record<string, unknown> = {};
+
+  for (const key of Object.keys(settings) as (keyof PossibleSettings)[]) {
+    if (EXCLUDED_KEYS.has(key)) continue;
+
+    const value = settings[key];
+    const defaultValue = defaults[key];
+
+    if (JSON.stringify(value) !== JSON.stringify(defaultValue)) {
+      nonDefault[key] = value;
+    }
+  }
+
+  if (Object.keys(nonDefault).length === 0) return undefined;
+  return JSON.stringify(nonDefault);
+}
+
+// for json parsing
+// if sting is invalid it should return empty obj
+export function deserializeCostingOptions(
+  costing: string | undefined
+): Partial<PossibleSettings> {
+  if (!costing) return {};
+  try {
+    const parsed: unknown = JSON.parse(costing);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return {};
+    }
+    return parsed as Partial<PossibleSettings>;
+  } catch {
+    return {};
+  }
+}

--- a/src/utils/route-schemas.ts
+++ b/src/utils/route-schemas.ts
@@ -11,7 +11,7 @@ export const searchParamsSchema = z.object({
   generalize: z.number().optional(),
   denoise: z.number().optional(),
   style: mapStyleSchema.optional(),
-  costing: z.string().optional(),
+  costing: fallback(z.record(z.unknown()).optional(), undefined),
 });
 
 export type SearchParamsSchema = z.infer<typeof searchParamsSchema>;

--- a/src/utils/route-schemas.ts
+++ b/src/utils/route-schemas.ts
@@ -11,6 +11,7 @@ export const searchParamsSchema = z.object({
   generalize: z.number().optional(),
   denoise: z.number().optional(),
   style: mapStyleSchema.optional(),
+  costing: z.string().optional(),
 });
 
 export type SearchParamsSchema = z.infer<typeof searchParamsSchema>;


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->
closes #335 
## 👨‍💻 Changes proposed
-Added a costing query parameter to the URL that stores any non-default costing options as JSON                                              
- Settings are restored from the URL on page load, so they survive refreshes and can be shared via permalink
- URL stays clean when everything is at defaults — the param only appears when something is changed
  
<!-- List all the proposed changes in your PR -->

## 📄 Note to reviewers
Only non-default values are sync to keep the URL short. exclude_polygons is intentionally skipped as it can hold large GeoJSON data.
<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots

<!-- Add any relevant screenshots if applicable -->
