### PR TITLE
fix: auto-calculate route from URL params on page load

### DIFF
--- a/src/components/directions/directions.tsx
+++ b/src/components/directions/directions.tsx
@@ -59,16 +59,24 @@ export const DirectionsControl = () => {
     if (wpsParam) {
       const coordinates = wpsParam.split(',').map(Number);
 
-      for (let i = 0; i < coordinates.length; i += 2) {
-        const lng = coordinates[i]!;
-        const lat = coordinates[i + 1]!;
+      const processWaypoints = async () => {
+        const geocodePromises: Promise<unknown>[] = [];
+        for (let i = 0; i < coordinates.length; i += 2) {
+          const lng = coordinates[i]!;
+          const lat = coordinates[i + 1]!;
 
-        if (!isValidCoordinates(lat, lng) || isNaN(lng) || isNaN(lat)) continue;
+          if (!isValidCoordinates(lat, lng) || isNaN(lng) || isNaN(lat))
+            continue;
 
-        const index = i / 2;
-        reverseGeocode(lng, lat, index, { isPermalink: true });
-      }
-      refetchDirections();
+          const index = i / 2;
+          geocodePromises.push(
+            reverseGeocode(lng, lat, index, { isPermalink: true })
+          );
+        }
+        await Promise.all(geocodePromises);
+        refetchDirections();
+      };
+      processWaypoints();
     }
 
     urlParamsProcessed.current = true;

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -310,12 +310,18 @@ export const MapComponent = () => {
       if (!popupLngLat) return;
       setShowContextPopup(false);
 
+      // Ensure the directions panel is open so DirectionsControl mounts
+      // and URL sync (wps param) runs
+      if (!directionsPanelOpen) {
+        toggleDirections();
+      }
+
       updateWaypointPosition({
         latLng: { lat: popupLngLat.lat, lng: popupLngLat.lng },
         index,
       });
     },
-    [popupLngLat, updateWaypointPosition]
+    [popupLngLat, updateWaypointPosition, directionsPanelOpen, toggleDirections]
   );
 
   const handleAddIsoWaypoint = useCallback(() => {

--- a/src/stores/common-store.ts
+++ b/src/stores/common-store.ts
@@ -51,7 +51,13 @@ export const useCommonStore = create<CommonStore>()(
   devtools(
     immer((set) => ({
       settingsPanelOpen: false,
-      directionsPanelOpen: false,
+      directionsPanelOpen: (() => {
+        try {
+          return new URL(window.location.href).searchParams.has('wps');
+        } catch {
+          return false;
+        }
+      })(),
       coordinates: [],
       loading: false,
       settings: { ...settingsInit },


### PR DESCRIPTION
Fixes #394
<img width="1363" height="585" alt="image" src="https://github.com/user-attachments/assets/f0b9e13f-1c7b-46ac-a356-89bc0a80bf66" />

now the url gets updated after setting the waypoints and pasting the url of the route also displays the route automatically in page reload