### PR TITLE
fix(routing): skip nominatim reverse geocode for map-placed waypoints

### DIFF
--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -305,13 +305,15 @@ export const MapComponent = () => {
       });
   }, []);
 
+  // handleAddWaypoint now receives the lngLat from MapContextMenu directly.
   const handleAddWaypoint = useCallback(
-    (index: number) => {
-      if (!popupLngLat) return;
+    (index: number, lngLat?: { lng: number; lat: number }) => {
+      const location = lngLat ?? popupLngLat;
+      if (!location) return;
       setShowContextPopup(false);
 
       updateWaypointPosition({
-        latLng: { lat: popupLngLat.lat, lng: popupLngLat.lng },
+        latLng: { lat: location.lat, lng: location.lng },
         index,
       });
     },

--- a/src/components/map/parts/map-context-menu.tsx
+++ b/src/components/map/parts/map-context-menu.tsx
@@ -4,7 +4,7 @@ import { useDirectionsStore } from '@/stores/directions-store';
 
 interface MapContextMenuProps {
   activeTab: string;
-  onAddWaypoint: (index: number) => void;
+  onAddWaypoint: (index: number, lngLat?: { lng: number; lat: number }) => void;
   onAddIsoWaypoint: () => void;
   popupLocation: { lng: number; lat: number };
 }
@@ -26,7 +26,11 @@ export function MapContextMenu({
         orientation="vertical"
         data-testid="button-group-right-context"
       >
-        <Button variant="outline" size="sm" onClick={() => onAddWaypoint(0)}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onAddWaypoint(0, popupLocation)}
+        >
           Directions from here
         </Button>
         <Button
@@ -37,7 +41,7 @@ export function MapContextMenu({
               index: waypointCount - 1,
               placeholder: popupLocation,
             });
-            onAddWaypoint(waypointCount - 1);
+            onAddWaypoint(waypointCount - 1, popupLocation);
           }}
         >
           Add as via point
@@ -45,7 +49,7 @@ export function MapContextMenu({
         <Button
           variant="outline"
           size="sm"
-          onClick={() => onAddWaypoint(waypointCount - 1)}
+          onClick={() => onAddWaypoint(waypointCount - 1, popupLocation)}
         >
           Directions to here
         </Button>

--- a/src/hooks/use-directions-queries.ts
+++ b/src/hooks/use-directions-queries.ts
@@ -90,7 +90,9 @@ export function useDirectionsQuery() {
         const data = await fetchDirections();
         if (data) {
           receiveRouteResults({ data });
-          zoomTo(data.decodedGeometry);
+          requestAnimationFrame(() => {
+            zoomTo(data.decodedGeometry);
+          });
         }
         return data;
       } catch (error) {
@@ -110,7 +112,7 @@ export function useDirectionsQuery() {
         }
         throw error;
       } finally {
-        setTimeout(() => showLoading(false), 500);
+        showLoading(false);
       }
     },
     enabled: false,
@@ -159,6 +161,27 @@ export function useReverseGeocodeDirections() {
 
     // Set placeholder immediately
     updatePlaceholderAddressAtIndex(index, lng, lat);
+
+    // If geocoding is disabled, skip the Nominatim round trip entirely.
+    const use_geocoding = useCommonStore.getState().settings.use_geocoding;
+    if (!use_geocoding) {
+      const coordTitle = `${lng.toFixed(6)}, ${lat.toFixed(6)}`;
+      const coordResult: ActiveWaypoint[] = [
+        {
+          title: coordTitle,
+          description: '',
+          selected: true,
+          addresslnglat: [lng, lat],
+          sourcelnglat: [lng, lat],
+          displaylnglat: [lng, lat],
+          key: 0,
+          addressindex: 0,
+        },
+      ];
+      receiveGeocodeResults({ addresses: coordResult, index });
+      updateTextInput({ inputValue: coordTitle, index, addressindex: 0 });
+      return coordResult;
+    }
 
     try {
       const addresses = await fetchReverseGeocode(lng, lat);


### PR DESCRIPTION
## 🛠️ Fixes Issue

Closes #371 

The main bottleneck in route render time was the Nominatim reverse geocode calls for waypoints placed via map click. 

## 👨‍💻 Changes proposed

### `src/hooks/use-directions-queries.ts`
- Check `use_geocoding` from the store before calling Nominatim in `useReverseGeocodeDirections.` If false, build a coordinate-only `ActiveWaypoint` directly with zero network requests.
- Remove `setTimeout(..., 500)` around `showLoading(false).`
- Wrap `zoomTo` in `requestAnimationFrame` so route layer paints first.

### `src/components/map/parts/map-context-menu.tsx`
- Add optional `lngLat` parameter to `onAddWaypoint` callback.
- Pass `popupLocation` through on all three waypoint buttons so the coordinates from the right-click event flow through to the handler.

### `src/components/map/index.tsx`
- Update `handleAddWaypoint` to accept and use the `lngLat` argument passed from `MapContextMenu`.

## Type of Change
- [x] Performance improvement
- [x] Bug fix
