### PR TITLE
feat: add access_restrictions MVT layer visualization

### DIFF
--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -50,6 +50,8 @@ import {
   VALHALLA_EDGES_LAYER_ID,
   VALHALLA_NODES_LAYER_ID,
   VALHALLA_SHORTCUTS_LAYER_ID,
+  VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID,
+  VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID,
 } from '@/components/tiles/valhalla-layers';
 import { MarkerIcon, type MarkerColor } from './parts/marker-icon';
 import { maxBounds } from './constants';
@@ -493,6 +495,8 @@ export const MapComponent = () => {
         VALHALLA_EDGES_LAYER_ID,
         VALHALLA_NODES_LAYER_ID,
         VALHALLA_SHORTCUTS_LAYER_ID,
+        VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID,
+        VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID,
       ].filter((layerId) => map.getLayer(layerId));
 
       if (availableLayers.length === 0) return;
@@ -738,7 +742,11 @@ export const MapComponent = () => {
         features.length > 0 &&
         (features[0]?.layer?.id === VALHALLA_EDGES_LAYER_ID ||
           features[0]?.layer?.id === VALHALLA_NODES_LAYER_ID ||
-          features[0]?.layer?.id === VALHALLA_SHORTCUTS_LAYER_ID);
+          features[0]?.layer?.id === VALHALLA_SHORTCUTS_LAYER_ID ||
+          features[0]?.layer?.id ===
+            VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID ||
+          features[0]?.layer?.id ===
+            VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID);
 
       if (isOverRoute) {
         onRouteLineHover(event);
@@ -797,6 +805,8 @@ export const MapComponent = () => {
                 VALHALLA_EDGES_LAYER_ID,
                 VALHALLA_NODES_LAYER_ID,
                 VALHALLA_SHORTCUTS_LAYER_ID,
+                VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID,
+                VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID,
               ]
             : ['routes-line']
         }

--- a/src/components/tiles/valhalla-layers-toggle.spec.tsx
+++ b/src/components/tiles/valhalla-layers-toggle.spec.tsx
@@ -9,6 +9,8 @@ import {
   VALHALLA_EDGES_LAYER_ID,
   VALHALLA_NODES_LAYER_ID,
   VALHALLA_SHORTCUTS_LAYER_ID,
+  VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID,
+  VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID,
 } from './valhalla-layers';
 
 const createMockMap = () => {
@@ -144,6 +146,12 @@ describe('ValhallaLayersToggle', () => {
         VALHALLA_SHORTCUTS_LAYER_ID
       );
       expect(mockMap.removeLayer).toHaveBeenCalledWith(VALHALLA_NODES_LAYER_ID);
+      expect(mockMap.removeLayer).toHaveBeenCalledWith(
+        VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID
+      );
+      expect(mockMap.removeLayer).toHaveBeenCalledWith(
+        VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID
+      );
     });
 
     it('should remove source when toggled off', async () => {

--- a/src/components/tiles/valhalla-layers.spec.ts
+++ b/src/components/tiles/valhalla-layers.spec.ts
@@ -9,9 +9,13 @@ import {
   VALHALLA_EDGES_LAYER_ID,
   VALHALLA_SHORTCUTS_LAYER_ID,
   VALHALLA_NODES_LAYER_ID,
+  VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID,
+  VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID,
   VALHALLA_EDGES_LAYER,
   VALHALLA_SHORTCUTS_LAYER,
   VALHALLA_NODES_LAYER,
+  VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER,
+  VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER,
   VALHALLA_LAYERS,
   getValhallaTileUrl,
   getValhallaSourceSpec,
@@ -36,13 +40,25 @@ describe('valhalla-layers', () => {
       expect(VALHALLA_EDGES_LAYER_ID).toBe('valhalla-edges');
       expect(VALHALLA_SHORTCUTS_LAYER_ID).toBe('valhalla-shortcuts');
       expect(VALHALLA_NODES_LAYER_ID).toBe('valhalla-nodes');
+      expect(VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID).toBe(
+        'valhalla-access-restrictions-permanent'
+      );
+      expect(VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID).toBe(
+        'valhalla-access-restrictions-timed'
+      );
     });
 
     it('should export VALHALLA_LAYERS array with all layers', () => {
-      expect(VALHALLA_LAYERS).toHaveLength(3);
+      expect(VALHALLA_LAYERS).toHaveLength(5);
       expect(VALHALLA_LAYERS).toContain(VALHALLA_EDGES_LAYER);
       expect(VALHALLA_LAYERS).toContain(VALHALLA_SHORTCUTS_LAYER);
       expect(VALHALLA_LAYERS).toContain(VALHALLA_NODES_LAYER);
+      expect(VALHALLA_LAYERS).toContain(
+        VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER
+      );
+      expect(VALHALLA_LAYERS).toContain(
+        VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER
+      );
     });
   });
 
@@ -140,6 +156,73 @@ describe('valhalla-layers', () => {
       expect(nodesLayer.paint).toHaveProperty('circle-stroke-color');
       expect(nodesLayer.paint).toHaveProperty('circle-stroke-width');
       expect(nodesLayer.paint).toHaveProperty('circle-opacity');
+    });
+  });
+
+  describe('VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER', () => {
+    const layer =
+      VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER as LineLayerSpecification;
+
+    it('should have correct id', () => {
+      expect(layer.id).toBe(VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID);
+    });
+
+    it('should be a line type layer', () => {
+      expect(layer.type).toBe('line');
+    });
+
+    it('should reference correct source', () => {
+      expect(layer.source).toBe(VALHALLA_SOURCE_ID);
+    });
+
+    it('should have access_restrictions source-layer', () => {
+      expect(layer['source-layer']).toBe('access_restrictions');
+    });
+
+    it('should filter out timed restrictions', () => {
+      expect(layer.filter).toEqual([
+        '!',
+        ['in', ['get', 'type'], ['literal', [6, 7]]],
+      ]);
+    });
+
+    it('should have paint properties', () => {
+      expect(layer.paint).toHaveProperty('line-color');
+      expect(layer.paint).toHaveProperty('line-width');
+      expect(layer.paint).toHaveProperty('line-opacity');
+    });
+  });
+
+  describe('VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER', () => {
+    const layer =
+      VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER as LineLayerSpecification;
+
+    it('should have correct id', () => {
+      expect(layer.id).toBe(VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID);
+    });
+
+    it('should be a line type layer', () => {
+      expect(layer.type).toBe('line');
+    });
+
+    it('should reference correct source', () => {
+      expect(layer.source).toBe(VALHALLA_SOURCE_ID);
+    });
+
+    it('should have access_restrictions source-layer', () => {
+      expect(layer['source-layer']).toBe('access_restrictions');
+    });
+
+    it('should filter to timed restrictions only', () => {
+      expect(layer.filter).toEqual([
+        'in',
+        ['get', 'type'],
+        ['literal', [6, 7]],
+      ]);
+    });
+
+    it('should have a dash array for visual distinction', () => {
+      expect(layer.paint).toHaveProperty('line-dasharray');
     });
   });
 

--- a/src/components/tiles/valhalla-layers.ts
+++ b/src/components/tiles/valhalla-layers.ts
@@ -5,6 +5,10 @@ export const VALHALLA_SOURCE_ID = 'valhalla-tiles';
 export const VALHALLA_EDGES_LAYER_ID = 'valhalla-edges';
 export const VALHALLA_SHORTCUTS_LAYER_ID = 'valhalla-shortcuts';
 export const VALHALLA_NODES_LAYER_ID = 'valhalla-nodes';
+export const VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID =
+  'valhalla-access-restrictions-permanent';
+export const VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID =
+  'valhalla-access-restrictions-timed';
 
 // Pre-encoded JSON: {"tile":{"z":{z},"x":{x},"y":{y}}}
 // Placeholders {z}, {x}, {y} remain unencoded for MapLibre to replace
@@ -128,8 +132,64 @@ export const VALHALLA_NODES_LAYER: LayerSpecification = {
   },
 };
 
+export const VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER: LayerSpecification =
+  {
+    id: VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID,
+    type: 'line',
+    source: VALHALLA_SOURCE_ID,
+    'source-layer': 'access_restrictions',
+    minzoom: 7,
+    maxzoom: 22,
+    filter: ['!', ['in', ['get', 'type'], ['literal', [6, 7]]]],
+    layout: { visibility: 'visible' },
+    paint: {
+      'line-color': '#e63946',
+      'line-width': [
+        'interpolate',
+        ['exponential', 1.5],
+        ['zoom'],
+        12,
+        2,
+        16,
+        4,
+        20,
+        6,
+      ],
+      'line-opacity': 0.9,
+    },
+  };
+
+export const VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER: LayerSpecification = {
+  id: VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID,
+  type: 'line',
+  source: VALHALLA_SOURCE_ID,
+  'source-layer': 'access_restrictions',
+  minzoom: 7,
+  maxzoom: 22,
+  filter: ['in', ['get', 'type'], ['literal', [6, 7]]],
+  layout: { visibility: 'visible' },
+  paint: {
+    'line-color': '#f4a261',
+    'line-dasharray': [4, 2],
+    'line-width': [
+      'interpolate',
+      ['exponential', 1.5],
+      ['zoom'],
+      12,
+      2,
+      16,
+      4,
+      20,
+      6,
+    ],
+    'line-opacity': 0.9,
+  },
+};
+
 export const VALHALLA_LAYERS: LayerSpecification[] = [
   VALHALLA_EDGES_LAYER,
   VALHALLA_SHORTCUTS_LAYER,
   VALHALLA_NODES_LAYER,
+  VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER,
+  VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER,
 ];


### PR DESCRIPTION
## 🛠️ Fixes Issue
Closes #390

## 👨‍💻 Changes proposed
- Added two new layer definitions in `valhalla-layers.ts`:
  - `valhalla-access-restrictions-permanent` - solid red line for permanent restrictions
  - `valhalla-access-restrictions-timed` - dashed orange line for timed/conditional restrictions
- Updated `index.tsx` to include both layers in click detection and interactive layer IDs
- Updated `valhalla-layers.spec.ts` and `valhalla-layers-toggle.spec.tsx` with tests for the new layers

## 📄 Note to reviewers
Styled permanent and timed restrictions differently rather than uniformly since they behave differently at runtime and a debugging tool should make that distinction clear at a glance. Used AccessType enum values (6, 7) from the backend to filter timed restrictions. Able to adjust if uniform styling is preferred.

## 📷 Screenshots
The access_restrictions layer renders two visually distinct styles:
- Solid red lines for permanent restrictions
- Dashed orange lines for timed/conditional restrictions

Toggling the layer on/off from the tiles panel shows/hides both.
<img width="858" height="357" alt="Screenshot from 2026-03-24 12-57-11" src="https://github.com/user-attachments/assets/7bb13175-a822-4ea0-ad97-e63aecaa4a20" />
<img width="858" height="357" alt="Screenshot from 2026-03-24 12-57-18" src="https://github.com/user-attachments/assets/d64b5d3c-7a13-4668-b8e8-15a5c1b9f313" />
