### PR TITLE
feat: add elevation support to export

### DIFF
--- a/src/components/directions/route-card.spec.tsx
+++ b/src/components/directions/route-card.spec.tsx
@@ -6,6 +6,8 @@ import type { ParsedDirectionsGeometry } from '@/components/types';
 
 const mockExportDataAsJson = vi.fn();
 const mockDownloadFile = vi.fn();
+const mockFetchHeight = vi.fn();
+const mockToastError = vi.fn();
 
 vi.mock('@/utils/export', () => ({
   exportDataAsJson: (...args: unknown[]) => mockExportDataAsJson(...args),
@@ -13,6 +15,16 @@ vi.mock('@/utils/export', () => ({
 
 vi.mock('@/utils/download-file', () => ({
   downloadFile: (...args: unknown[]) => mockDownloadFile(...args),
+}));
+
+vi.mock('@/utils/height', () => ({
+  fetchHeight: (...args: unknown[]) => mockFetchHeight(...args),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
 }));
 
 vi.mock('@/utils/date-time', () => ({
@@ -92,6 +104,7 @@ const createMockData = (
 describe('RouteCard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFetchHeight.mockResolvedValue({ height: [100, 101, 102] });
   });
 
   it('should render without crashing', () => {
@@ -240,6 +253,77 @@ describe('RouteCard', () => {
       fileName: 'valhalla-directions_2024-01-01_12-00-00.geojson',
       fileType: 'text/json',
     });
+  });
+
+  it('should fetch elevation and export JSON with elevation when option is enabled', async () => {
+    const user = userEvent.setup();
+    const baseData = createMockData();
+    const firstLeg = baseData.trip.legs[0]!;
+    const data = createMockData({
+      trip: {
+        ...baseData.trip,
+        legs: [
+          ...baseData.trip.legs,
+          {
+            ...firstLeg,
+            shape: 'encoded-2',
+          },
+        ],
+      },
+    });
+
+    render(
+      <RouteCard data={data} index={0} isActive={true} onSelect={vi.fn()} />
+    );
+
+    await user.click(screen.getByRole('button', { name: /export/i }));
+    await user.click(screen.getByRole('menuitemradio', { name: 'JSON' }));
+    await user.click(
+      screen.getByRole('menuitemcheckbox', { name: 'Include elevation' })
+    );
+    await user.click(screen.getByTestId('export-action-button'));
+
+    expect(mockFetchHeight).toHaveBeenCalledWith({
+      coordinates: data.decodedGeometry,
+    });
+
+    const callArg = mockDownloadFile.mock.calls[0]?.[0] as {
+      data: string;
+      fileName: string;
+      fileType: string;
+    };
+    const exportedJson = JSON.parse(callArg.data);
+
+    expect(callArg.fileName).toBe(
+      'valhalla-directions_2024-01-01_12-00-00_with_elevation.json'
+    );
+    expect(exportedJson.trip.legs).toHaveLength(2);
+    expect(exportedJson.trip.legs[0].elevation_interval).toBe(30);
+    expect(exportedJson.trip.legs[0].elevation).toEqual([100, 101, 102]);
+    expect(exportedJson.trip.legs[1].elevation_interval).toBe(30);
+    expect(exportedJson.trip.legs[1].elevation).toEqual([100, 101, 102]);
+  });
+
+  it('should show error toast and skip download when elevation fetch fails', async () => {
+    const user = userEvent.setup();
+    const data = createMockData();
+    mockFetchHeight.mockRejectedValueOnce(new Error('network failed'));
+
+    render(
+      <RouteCard data={data} index={0} isActive={true} onSelect={vi.fn()} />
+    );
+
+    await user.click(screen.getByRole('button', { name: /export/i }));
+    await user.click(
+      screen.getByRole('menuitemcheckbox', { name: 'Include elevation' })
+    );
+    await user.click(screen.getByTestId('export-action-button'));
+
+    expect(mockToastError).toHaveBeenCalledWith(
+      'Failed to fetch elevation data.',
+      expect.any(Object)
+    );
+    expect(mockDownloadFile).not.toHaveBeenCalled();
   });
 
   it('should convert coordinates to GeoJSON format (lng, lat)', async () => {

--- a/src/components/directions/route-card.spec.tsx
+++ b/src/components/directions/route-card.spec.tsx
@@ -194,13 +194,20 @@ describe('RouteCard', () => {
 
     await user.click(screen.getByRole('button', { name: /export/i }));
 
-    expect(screen.getByRole('menuitem', { name: 'JSON' })).toBeInTheDocument();
+    expect(screen.getByText('Format')).toBeInTheDocument();
+    expect(screen.getByText('Options')).toBeInTheDocument();
     expect(
-      screen.getByRole('menuitem', { name: 'GeoJSON' })
+      screen.getByRole('menuitemradio', { name: 'JSON' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitemradio', { name: 'GeoJSON' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitemcheckbox', { name: 'Include elevation' })
     ).toBeInTheDocument();
   });
 
-  it('should call exportDataAsJson when JSON is clicked', async () => {
+  it('should call exportDataAsJson when JSON format is selected and Export is clicked', async () => {
     const user = userEvent.setup();
     const data = createMockData();
     render(
@@ -208,7 +215,8 @@ describe('RouteCard', () => {
     );
 
     await user.click(screen.getByRole('button', { name: /export/i }));
-    await user.click(screen.getByRole('menuitem', { name: 'JSON' }));
+    await user.click(screen.getByRole('menuitemradio', { name: 'JSON' }));
+    await user.click(screen.getByTestId('export-action-button'));
 
     expect(mockExportDataAsJson).toHaveBeenCalledWith(
       data,
@@ -216,7 +224,7 @@ describe('RouteCard', () => {
     );
   });
 
-  it('should call downloadFile with GeoJSON when GeoJSON is clicked', async () => {
+  it('should call downloadFile with GeoJSON when GeoJSON format is selected and Export is clicked', async () => {
     const user = userEvent.setup();
     const data = createMockData();
     render(
@@ -224,7 +232,8 @@ describe('RouteCard', () => {
     );
 
     await user.click(screen.getByRole('button', { name: /export/i }));
-    await user.click(screen.getByRole('menuitem', { name: 'GeoJSON' }));
+    await user.click(screen.getByRole('menuitemradio', { name: 'GeoJSON' }));
+    await user.click(screen.getByTestId('export-action-button'));
 
     expect(mockDownloadFile).toHaveBeenCalledWith({
       data: expect.stringContaining('"type": "Feature"'),
@@ -243,7 +252,8 @@ describe('RouteCard', () => {
     );
 
     await user.click(screen.getByRole('button', { name: /export/i }));
-    await user.click(screen.getByRole('menuitem', { name: 'GeoJSON' }));
+    await user.click(screen.getByRole('menuitemradio', { name: 'GeoJSON' }));
+    await user.click(screen.getByTestId('export-action-button'));
 
     const callArg = mockDownloadFile.mock.calls[0]?.[0] as {
       data: string;

--- a/src/components/directions/route-card.tsx
+++ b/src/components/directions/route-card.tsx
@@ -26,6 +26,7 @@ import { Separator } from '@/components/ui/separator';
 import { exportDataAsJson } from '@/utils/export';
 import { getDateTimeString } from '@/utils/date-time';
 import { fetchHeight } from '@/utils/height';
+import { toast } from 'sonner';
 
 interface RouteCardProps {
   data: ParsedDirectionsGeometry;
@@ -74,10 +75,27 @@ export const RouteCard = ({
     async (isGeoJson: boolean = false) => {
       const coordinates = data?.decodedGeometry;
       if (!coordinates) return;
-      const elevationData = fetchHeight({ coordinates });
-      const elevationResults = await elevationData;
-      if (!elevationResults || !elevationResults.height) {
-        alert('Failed to fetch elevation data.');
+
+      let elevationResults: Awaited<ReturnType<typeof fetchHeight>>;
+      try {
+        elevationResults = await fetchHeight({
+          coordinates: coordinates as [number, number][],
+        });
+      } catch {
+        toast.error('Failed to fetch elevation data.', {
+          position: 'bottom-center',
+          duration: 5000,
+          closeButton: true,
+        });
+        return;
+      }
+
+      if (!elevationResults.height) {
+        toast.error('Failed to fetch elevation data.', {
+          position: 'bottom-center',
+          duration: 5000,
+          closeButton: true,
+        });
         return;
       }
 
@@ -86,13 +104,11 @@ export const RouteCard = ({
           ...data,
           trip: {
             ...data.trip,
-            legs: [
-              {
-                ...data.trip.legs[0],
-                elevation_interval: 30,
-                elevation: elevationResults.height,
-              },
-            ],
+            legs: (data.trip.legs ?? []).map((leg) => ({
+              ...leg,
+              elevation_interval: 30,
+              elevation: elevationResults.height,
+            })),
           },
         };
         const formattedData = JSON.stringify(dataWithElevation, null, 2);
@@ -208,17 +224,20 @@ export const RouteCard = ({
                 <DropdownMenuLabel className="text-xs text-muted-foreground font-semibold uppercase tracking-wide px-2 py-1">
                   Format
                 </DropdownMenuLabel>
-                <DropdownMenuRadioGroup value={exportFormat}>
+                <DropdownMenuRadioGroup
+                  value={exportFormat}
+                  onValueChange={(value) =>
+                    setExportFormat(value as 'geojson' | 'json')
+                  }
+                >
                   <DropdownMenuRadioItem
                     value="geojson"
-                    onClick={() => setExportFormat('geojson')}
                     onSelect={(e) => e.preventDefault()}
                   >
                     GeoJSON
                   </DropdownMenuRadioItem>
                   <DropdownMenuRadioItem
                     value="json"
-                    onClick={() => setExportFormat('json')}
                     onSelect={(e) => e.preventDefault()}
                   >
                     JSON

--- a/src/components/directions/route-card.tsx
+++ b/src/components/directions/route-card.tsx
@@ -12,15 +12,20 @@ import {
 } from '@/components/ui/collapsible';
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Download } from 'lucide-react';
+import { ChevronDown, Download } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Separator } from '@/components/ui/separator';
 import { exportDataAsJson } from '@/utils/export';
 import { getDateTimeString } from '@/utils/date-time';
+import { fetchHeight } from '@/utils/height';
 
 interface RouteCardProps {
   data: ParsedDirectionsGeometry;
@@ -36,6 +41,11 @@ export const RouteCard = ({
   onSelect,
 }: RouteCardProps) => {
   const [showManeuvers, setShowManeuvers] = useState(false);
+  const [includeElevation, setIncludeElevation] = useState(false);
+  const [exportFormat, setExportFormat] = useState<'geojson' | 'json'>(
+    'geojson'
+  );
+  const [isExportMenuOpen, setIsExportMenuOpen] = useState(false);
 
   const exportToGeoJson = useCallback(() => {
     const coordinates = data?.decodedGeometry;
@@ -59,6 +69,94 @@ export const RouteCard = ({
       fileType: 'text/json',
     });
   }, [data]);
+
+  const exportWithElevation = useCallback(
+    async (isGeoJson: boolean = false) => {
+      const coordinates = data?.decodedGeometry;
+      if (!coordinates) return;
+      const elevationData = fetchHeight({ coordinates });
+      const elevationResults = await elevationData;
+      if (!elevationResults || !elevationResults.height) {
+        alert('Failed to fetch elevation data.');
+        return;
+      }
+
+      if (!isGeoJson) {
+        const dataWithElevation = {
+          ...data,
+          trip: {
+            ...data.trip,
+            legs: [
+              {
+                ...data.trip.legs[0],
+                elevation_interval: 30,
+                elevation: elevationResults.height,
+              },
+            ],
+          },
+        };
+        const formattedData = JSON.stringify(dataWithElevation, null, 2);
+        downloadFile({
+          data: formattedData,
+          fileName:
+            'valhalla-directions_' +
+            getDateTimeString() +
+            '_with_elevation.json',
+          fileType: 'text/json',
+        });
+        return;
+      }
+
+      const geoJsonCoordinates = coordinates.map(([lat, lng]) => [lng, lat]);
+
+      const geoJson = {
+        type: 'Feature',
+        geometry: {
+          type: 'LineString',
+          coordinates: geoJsonCoordinates,
+        },
+        properties: {
+          elevation_interval: 30,
+          elevation: elevationResults.height,
+        },
+      };
+      const formattedData = JSON.stringify(geoJson, null, 2);
+      downloadFile({
+        data: formattedData,
+        fileName:
+          'valhalla-directions_' +
+          getDateTimeString() +
+          '_with_elevation.geojson',
+        fileType: 'text/json',
+      });
+    },
+    [data]
+  );
+
+  const handleExport = useCallback(async () => {
+    if (exportFormat === 'json') {
+      if (includeElevation) {
+        await exportWithElevation();
+      } else {
+        exportDataAsJson(data, 'valhalla-directions');
+      }
+      setIsExportMenuOpen(false);
+      return;
+    }
+
+    if (includeElevation) {
+      await exportWithElevation(true);
+    } else {
+      exportToGeoJson();
+    }
+    setIsExportMenuOpen(false);
+  }, [
+    data,
+    exportFormat,
+    includeElevation,
+    exportToGeoJson,
+    exportWithElevation,
+  ]);
 
   if (!data.trip) {
     return null;
@@ -95,22 +193,60 @@ export const RouteCard = ({
                 {showManeuvers ? 'Hide Maneuvers' : 'Show Maneuvers'}
               </Button>
             </CollapsibleTrigger>
-            <DropdownMenu>
+            <DropdownMenu
+              open={isExportMenuOpen}
+              onOpenChange={setIsExportMenuOpen}
+            >
               <DropdownMenuTrigger asChild>
                 <Button variant="outline" size="sm">
                   <Download className="size-4" />
                   Export
+                  <ChevronDown className="size-4" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                <DropdownMenuItem
-                  onClick={() => exportDataAsJson(data, 'valhalla-directions')}
+              <DropdownMenuContent className="w-56 p-2" align="end">
+                <DropdownMenuLabel className="text-xs text-muted-foreground font-semibold uppercase tracking-wide px-2 py-1">
+                  Format
+                </DropdownMenuLabel>
+                <DropdownMenuRadioGroup value={exportFormat}>
+                  <DropdownMenuRadioItem
+                    value="geojson"
+                    onClick={() => setExportFormat('geojson')}
+                    onSelect={(e) => e.preventDefault()}
+                  >
+                    GeoJSON
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem
+                    value="json"
+                    onClick={() => setExportFormat('json')}
+                    onSelect={(e) => e.preventDefault()}
+                  >
+                    JSON
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="text-xs text-muted-foreground font-semibold uppercase tracking-wide px-2 py-1">
+                  Options
+                </DropdownMenuLabel>
+                <DropdownMenuCheckboxItem
+                  checked={includeElevation}
+                  onCheckedChange={(checked) => setIncludeElevation(!!checked)}
+                  onSelect={(e) => e.preventDefault()}
                 >
-                  JSON
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={exportToGeoJson}>
-                  GeoJSON
-                </DropdownMenuItem>
+                  Include elevation
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuSeparator />
+                <div className="px-1 pt-1">
+                  <Button
+                    data-testid="export-action-button"
+                    size="sm"
+                    className="w-full"
+                    onClick={handleExport}
+                  >
+                    <Download className="size-4" />
+                    Export
+                  </Button>
+                </div>
               </DropdownMenuContent>
             </DropdownMenu>
           </div>

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
-import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
+import { CheckIcon, ChevronRightIcon } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
@@ -90,13 +90,13 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[state=checked]:[&_span]:border-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
       {...props}
     >
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center rounded-[4px] border border-muted-foreground/60">
         <DropdownMenuPrimitive.ItemIndicator>
           <CheckIcon className="size-4" />
         </DropdownMenuPrimitive.ItemIndicator>
@@ -126,15 +126,13 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[state=checked]:[&_span]:border-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
     >
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="size-2 fill-current" />
-        </DropdownMenuPrimitive.ItemIndicator>
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center rounded-full border border-muted-foreground/60">
+        <DropdownMenuPrimitive.ItemIndicator className="flex size-2 rounded-full bg-current" />
       </span>
       {children}
     </DropdownMenuPrimitive.RadioItem>

--- a/src/utils/height.ts
+++ b/src/utils/height.ts
@@ -1,0 +1,43 @@
+import { getValhallaUrl } from './valhalla';
+
+type Coordinates = number[][];
+
+export const fetchHeight = async ({
+  coordinates,
+}: {
+  coordinates: Coordinates;
+}) => {
+  const resample_distance = 30; // meters
+  const height_precision = 2;
+
+  const heightPayload = {
+    shape: coordinates.map((coord) => ({ lat: coord[0], lon: coord[1] })),
+    resample_distance,
+    height_precision,
+    id: 'valhalla_height',
+  };
+
+  try {
+    const res = await fetch(`${getValhallaUrl()}/height`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(heightPayload),
+    });
+
+    if (!res.ok) {
+      throw new Error(
+        `Failed to fetch height (${res.status} ${res.statusText})`
+      );
+    }
+
+    const data = await res.json();
+    return data;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to fetch height data: ${error.message}`);
+    }
+    throw new Error('Failed to fetch height data: Unknown error');
+  }
+};

--- a/src/utils/height.ts
+++ b/src/utils/height.ts
@@ -1,17 +1,21 @@
 import { getValhallaUrl } from './valhalla';
 
-type Coordinates = number[][];
+type LatLng = [lat: number, lng: number];
+
+interface HeightResponse {
+  height?: number[];
+}
 
 export const fetchHeight = async ({
   coordinates,
 }: {
-  coordinates: Coordinates;
-}) => {
+  coordinates: LatLng[];
+}): Promise<HeightResponse> => {
   const resample_distance = 30; // meters
   const height_precision = 2;
 
   const heightPayload = {
-    shape: coordinates.map((coord) => ({ lat: coord[0], lon: coord[1] })),
+    shape: coordinates.map(([lat, lng]) => ({ lat, lon: lng })),
     resample_distance,
     height_precision,
     id: 'valhalla_height',


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

feat: Add option to include elevation for download

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->
Closes #211 

## 👨‍💻 Changes proposed
- added a prop in `buildDirectionRequest` to include `elevations`.
- updated `useDirectionQuery` to accept a prop for the same and return directions with `elevations`.
- added a checkbox for elevation in the dropdown.
- With checked, it makes an additional call with params: `elevation_interval: 30` before downloading.
<!-- List all the proposed changes in your PR -->

## 📄 Note to reviewers
AI: used for generating tests.
<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots
<img width="462" height="299" alt="image" src="https://github.com/user-attachments/assets/c79c5b85-d835-4f68-b663-afdd02e66c3c" />

<!-- Add any relevant screenshots if applicable -->
