### PR TITLE
Add expansion tile visualization

### DIFF
--- a/src/components/map/index.spec.tsx
+++ b/src/components/map/index.spec.tsx
@@ -823,6 +823,46 @@ describe('MapComponent', () => {
       vi.useRealTimers();
     });
 
+    it('should query expansion layers when they exist', async () => {
+      vi.useFakeTimers();
+      mockGetLayer.mockImplementation((layerId?: string) =>
+        layerId === 'valhalla-expansion-edges'
+          ? { id: 'valhalla-expansion-edges' }
+          : undefined
+      );
+      mockQueryRenderedFeatures.mockReturnValue([
+        {
+          type: 'Feature',
+          sourceLayer: 'edges',
+          properties: { id: 'exp-1', edge_status: 'reached' },
+          geometry: {
+            type: 'LineString',
+            coordinates: [
+              [0, 0],
+              [1, 1],
+            ],
+          },
+          layer: { id: 'valhalla-expansion-edges' },
+        },
+      ]);
+
+      render(<MapComponent />);
+
+      fireEvent.click(screen.getByTestId('map'));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(250);
+      });
+
+      expect(mockQueryRenderedFeatures).toHaveBeenCalledWith(
+        { x: 100, y: 100 },
+        { layers: ['valhalla-expansion-edges'] }
+      );
+      expect(screen.getByTestId('tiles-info-popup')).toBeInTheDocument();
+
+      vi.useRealTimers();
+    });
+
     it('should close tiles info popup when close button is clicked', async () => {
       vi.useFakeTimers();
       mockGetLayer.mockReturnValue(true);

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -46,13 +46,8 @@ import { MapInfoPopup } from './parts/map-info-popup';
 import { MapContextMenu } from './parts/map-context-menu';
 import { RouteHoverPopup } from './parts/route-hover-popup';
 import { TilesInfoPopup } from './parts/tiles-info-popup';
-import {
-  VALHALLA_EDGES_LAYER_ID,
-  VALHALLA_NODES_LAYER_ID,
-  VALHALLA_SHORTCUTS_LAYER_ID,
-  VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID,
-  VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID,
-} from '@/components/tiles/valhalla-layers';
+import { VALHALLA_LAYERS } from '@/components/tiles/valhalla-layers';
+import { EXPANSION_LAYERS } from '@/components/tiles/expansion-layers';
 import { MarkerIcon, type MarkerColor } from './parts/marker-icon';
 import { maxBounds } from './constants';
 import { getInitialMapPosition, LAST_CENTER_KEY } from './utils';
@@ -70,6 +65,11 @@ import {
 import { toast } from 'sonner';
 
 const { center, zoom: zoom_initial } = getInitialMapPosition();
+
+const TILE_INTERACTIVE_LAYER_IDS = [
+  ...VALHALLA_LAYERS.map((layer) => layer.id),
+  ...EXPANSION_LAYERS.map((layer) => layer.id),
+];
 
 interface MarkerData {
   id: string;
@@ -491,13 +491,9 @@ export const MapComponent = () => {
 
       const map = mapRef.current.getMap();
 
-      const availableLayers = [
-        VALHALLA_EDGES_LAYER_ID,
-        VALHALLA_NODES_LAYER_ID,
-        VALHALLA_SHORTCUTS_LAYER_ID,
-        VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID,
-        VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID,
-      ].filter((layerId) => map.getLayer(layerId));
+      const availableLayers = TILE_INTERACTIVE_LAYER_IDS.filter((layerId) =>
+        map.getLayer(layerId)
+      );
 
       if (availableLayers.length === 0) return;
 
@@ -740,13 +736,7 @@ export const MapComponent = () => {
       const isOverTiles =
         features &&
         features.length > 0 &&
-        (features[0]?.layer?.id === VALHALLA_EDGES_LAYER_ID ||
-          features[0]?.layer?.id === VALHALLA_NODES_LAYER_ID ||
-          features[0]?.layer?.id === VALHALLA_SHORTCUTS_LAYER_ID ||
-          features[0]?.layer?.id ===
-            VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID ||
-          features[0]?.layer?.id ===
-            VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID);
+        TILE_INTERACTIVE_LAYER_IDS.includes(features[0]?.layer?.id ?? '');
 
       if (isOverRoute) {
         onRouteLineHover(event);
@@ -800,15 +790,7 @@ export const MapComponent = () => {
         onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeave}
         interactiveLayerIds={
-          activeTab === 'tiles'
-            ? [
-                VALHALLA_EDGES_LAYER_ID,
-                VALHALLA_NODES_LAYER_ID,
-                VALHALLA_SHORTCUTS_LAYER_ID,
-                VALHALLA_ACCESS_RESTRICTIONS_PERMANENT_LAYER_ID,
-                VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID,
-              ]
-            : ['routes-line']
+          activeTab === 'tiles' ? TILE_INTERACTIVE_LAYER_IDS : ['routes-line']
         }
         mapStyle={resolvedMapStyle}
         style={{ width: '100%', height: '100vh' }}

--- a/src/components/map/parts/tiles-info-popup.spec.tsx
+++ b/src/components/map/parts/tiles-info-popup.spec.tsx
@@ -84,6 +84,20 @@ describe('TilesInfoPopup', () => {
     expect(screen.getByText('Shortcut')).toBeInTheDocument();
   });
 
+  it('should display "Expansion Edge" label for expansion edge features', () => {
+    const expansionFeature = {
+      ...createMockFeature('edges', {
+        id: '34567',
+        edge_status: 'reached',
+      }),
+      layer: { id: 'valhalla-expansion-edges' },
+    } as MapGeoJSONFeature;
+
+    render(<TilesInfoPopup features={[expansionFeature]} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Expansion Edge')).toBeInTheDocument();
+  });
+
   it('should display all properties of a feature', () => {
     render(<TilesInfoPopup {...defaultProps} />);
 

--- a/src/components/map/parts/tiles-info-popup.tsx
+++ b/src/components/map/parts/tiles-info-popup.tsx
@@ -30,6 +30,9 @@ export function TilesInfoPopup({ features, onClose }: TilesInfoPopupProps) {
         let layerType = 'Node';
         if (isEdge) layerType = 'Edge';
         else if (isShortcut) layerType = 'Shortcut';
+        if (feature.layer?.id?.includes('expansion') && isEdge) {
+          layerType = 'Expansion Edge';
+        }
         const properties = feature.properties || {};
         const Icon = isEdgeLike ? Route : MapPin;
 

--- a/src/components/tiles/custom-layer-editor.tsx
+++ b/src/components/tiles/custom-layer-editor.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
 import { VALHALLA_SOURCE_ID } from './valhalla-layers';
+import { EXPANSION_SOURCE_ID } from './expansion-layers';
 
 const EXAMPLE_LAYER = JSON.stringify(
   {
@@ -48,7 +49,7 @@ export const CustomLayerEditor = ({
   const [open, setOpen] = useState(false);
   const [jsonValue, setJsonValue] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [valhallaEnabled, setValhallaEnabled] = useState(false);
+  const [sourceLayersEnabled, setSourceLayersEnabled] = useState(false);
 
   useEffect(() => {
     if (!mainMap) return;
@@ -56,7 +57,10 @@ export const CustomLayerEditor = ({
     const map = mainMap.getMap();
 
     const handleStyleData = () => {
-      setValhallaEnabled(!!map.getSource(VALHALLA_SOURCE_ID));
+      setSourceLayersEnabled(
+        !!map.getSource(VALHALLA_SOURCE_ID) ||
+          !!map.getSource(EXPANSION_SOURCE_ID)
+      );
     };
 
     map.on('styledata', handleStyleData);
@@ -122,7 +126,7 @@ export const CustomLayerEditor = ({
           variant="outline"
           size="sm"
           className="w-full gap-2"
-          disabled={!valhallaEnabled}
+          disabled={!sourceLayersEnabled}
         >
           <Plus className="size-4" />
           Add Custom Layer
@@ -144,6 +148,10 @@ export const CustomLayerEditor = ({
             as JSON. Use{' '}
             <code className="text-xs bg-muted px-1 rounded">
               valhalla-tiles
+            </code>{' '}
+            or{' '}
+            <code className="text-xs bg-muted px-1 rounded">
+              valhalla-expansion
             </code>{' '}
             as the source to visualize Valhalla tile attributes.
           </DialogDescription>

--- a/src/components/tiles/expansion-layers-toggle.spec.tsx
+++ b/src/components/tiles/expansion-layers-toggle.spec.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { LayerSpecification } from 'maplibre-gl';
+import { ExpansionLayersToggle } from './expansion-layers-toggle';
+import {
+  EXPANSION_SOURCE_ID,
+  EXPANSION_LAYERS,
+  EXPANSION_EDGES_LAYER_ID,
+} from './expansion-layers';
+
+const createMockMap = () => {
+  const sources: Record<string, unknown> = {};
+  const layers: Record<string, unknown> = {};
+
+  return {
+    getSource: vi.fn((id: string) => sources[id]),
+    addSource: vi.fn((id: string, spec: unknown) => {
+      sources[id] = spec;
+    }),
+    removeSource: vi.fn((id: string) => {
+      delete sources[id];
+    }),
+    getLayer: vi.fn((id: string) => layers[id]),
+    addLayer: vi.fn((layer: { id: string }) => {
+      layers[layer.id] = layer;
+    }),
+    removeLayer: vi.fn((id: string) => {
+      delete layers[id];
+    }),
+    setLayoutProperty: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    _sources: sources,
+    _layers: layers,
+  };
+};
+
+let mockMap = createMockMap();
+let mockMapReady = true;
+
+vi.mock('react-map-gl/maplibre', () => ({
+  useMap: vi.fn(() => ({
+    mainMap: {
+      getMap: () => mockMap,
+    },
+  })),
+}));
+
+vi.mock('@/stores/common-store', () => ({
+  useCommonStore: vi.fn((selector) =>
+    selector({
+      mapReady: mockMapReady,
+    })
+  ),
+}));
+
+const noCustomLayers: { layer: LayerSpecification; visible: boolean }[] = [];
+
+describe('ExpansionLayersToggle', () => {
+  beforeEach(() => {
+    mockMap = createMockMap();
+    mockMapReady = true;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should render the expansion toggle label', () => {
+    render(<ExpansionLayersToggle customLayers={noCustomLayers} />);
+
+    expect(screen.getByText('Append Expansion layers')).toBeInTheDocument();
+  });
+
+  it('should add the expansion source and layer when toggled on', async () => {
+    const user = userEvent.setup();
+    render(<ExpansionLayersToggle customLayers={noCustomLayers} />);
+
+    await user.click(screen.getByRole('switch'));
+
+    expect(mockMap.addSource).toHaveBeenCalledWith(
+      EXPANSION_SOURCE_ID,
+      expect.objectContaining({
+        type: 'vector',
+        tiles: [expect.stringContaining('/expansion?json=')],
+      })
+    );
+    expect(mockMap.addLayer).toHaveBeenCalledWith(EXPANSION_LAYERS[0]);
+  });
+
+  it('should remove the expansion layer and source when toggled off', async () => {
+    const user = userEvent.setup();
+    render(<ExpansionLayersToggle customLayers={noCustomLayers} />);
+
+    const toggle = screen.getByRole('switch');
+    await user.click(toggle);
+    await user.click(toggle);
+
+    expect(mockMap.removeLayer).toHaveBeenCalledWith(EXPANSION_EDGES_LAYER_ID);
+    expect(mockMap.removeSource).toHaveBeenCalledWith(EXPANSION_SOURCE_ID);
+  });
+
+  it('should sync enabled state with source existence on style change', async () => {
+    render(<ExpansionLayersToggle customLayers={noCustomLayers} />);
+
+    const styleDataHandler = mockMap.on.mock.calls.find(
+      (call) => call[0] === 'styledata'
+    )?.[1];
+
+    mockMap._sources[EXPANSION_SOURCE_ID] = { type: 'vector' };
+
+    await act(async () => {
+      styleDataHandler?.();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch')).toBeChecked();
+    });
+  });
+});

--- a/src/components/tiles/expansion-layers-toggle.tsx
+++ b/src/components/tiles/expansion-layers-toggle.tsx
@@ -1,0 +1,25 @@
+import type { LayerSpecification } from 'maplibre-gl';
+import { SourceLayersToggle } from './source-layers-toggle';
+import {
+  EXPANSION_LAYERS,
+  EXPANSION_SOURCE_ID,
+  getExpansionSourceSpec,
+} from './expansion-layers';
+
+interface ExpansionLayersToggleProps {
+  customLayers: { layer: LayerSpecification; visible: boolean }[];
+}
+
+export const ExpansionLayersToggle = ({
+  customLayers,
+}: ExpansionLayersToggleProps) => {
+  return (
+    <SourceLayersToggle
+      label="Append Expansion layers"
+      sourceId={EXPANSION_SOURCE_ID}
+      layers={EXPANSION_LAYERS}
+      customLayers={customLayers}
+      buildSourceSpec={getExpansionSourceSpec}
+    />
+  );
+};

--- a/src/components/tiles/expansion-layers.spec.ts
+++ b/src/components/tiles/expansion-layers.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import type { LineLayerSpecification } from 'maplibre-gl';
+import {
+  EXPANSION_SOURCE_ID,
+  EXPANSION_EDGES_LAYER_ID,
+  EXPANSION_EDGES_LAYER,
+  EXPANSION_LAYERS,
+} from './expansion-layers';
+
+describe('expansion-layers', () => {
+  it('should export the expected source and layer ids', () => {
+    expect(EXPANSION_SOURCE_ID).toBe('valhalla-expansion');
+    expect(EXPANSION_EDGES_LAYER_ID).toBe('valhalla-expansion-edges');
+  });
+
+  it('should export the expansion layer collection', () => {
+    expect(EXPANSION_LAYERS).toHaveLength(1);
+    expect(EXPANSION_LAYERS[0]).toBe(EXPANSION_EDGES_LAYER);
+  });
+
+  it('should define an edge line layer with status-based styling', () => {
+    const layer = EXPANSION_EDGES_LAYER as LineLayerSpecification;
+
+    expect(layer.type).toBe('line');
+    expect(layer.source).toBe(EXPANSION_SOURCE_ID);
+    expect(layer['source-layer']).toBe('edges');
+    expect(layer.paint).toMatchObject({
+      'line-color': [
+        'match',
+        ['get', 'edge_status'],
+        'reached',
+        '#16a34a',
+        'settled',
+        '#f59e0b',
+        'connected',
+        '#2563eb',
+        '#64748b',
+      ],
+      'line-opacity': 0.9,
+    });
+  });
+});

--- a/src/components/tiles/expansion-layers.ts
+++ b/src/components/tiles/expansion-layers.ts
@@ -1,0 +1,47 @@
+import type { LayerSpecification } from 'maplibre-gl';
+import { getExpansionSourceSpec } from './valhalla-layers';
+
+export const EXPANSION_SOURCE_ID = 'valhalla-expansion';
+export const EXPANSION_EDGES_LAYER_ID = 'valhalla-expansion-edges';
+
+export const EXPANSION_EDGES_LAYER: LayerSpecification = {
+  id: EXPANSION_EDGES_LAYER_ID,
+  type: 'line',
+  source: EXPANSION_SOURCE_ID,
+  'source-layer': 'edges',
+  minzoom: 7,
+  maxzoom: 22,
+  filter: ['all'],
+  layout: { visibility: 'visible' },
+  paint: {
+    'line-color': [
+      'match',
+      ['get', 'edge_status'],
+      'reached',
+      '#16a34a',
+      'settled',
+      '#f59e0b',
+      'connected',
+      '#2563eb',
+      '#64748b',
+    ],
+    'line-width': [
+      'interpolate',
+      ['linear'],
+      ['zoom'],
+      10,
+      1.5,
+      14,
+      2.5,
+      18,
+      4,
+      22,
+      5.5,
+    ],
+    'line-opacity': 0.9,
+  },
+};
+
+export const EXPANSION_LAYERS: LayerSpecification[] = [EXPANSION_EDGES_LAYER];
+
+export { getExpansionSourceSpec };

--- a/src/components/tiles/source-layers-toggle.tsx
+++ b/src/components/tiles/source-layers-toggle.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useMap } from 'react-map-gl/maplibre';
+import type { LayerSpecification, SourceSpecification } from 'maplibre-gl';
+import { useCommonStore } from '@/stores/common-store';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+
+interface SourceLayersToggleProps {
+  label: string;
+  sourceId: string;
+  layers: LayerSpecification[];
+  customLayers: { layer: LayerSpecification; visible: boolean }[];
+  buildSourceSpec: () => SourceSpecification;
+}
+
+export const SourceLayersToggle = ({
+  label,
+  sourceId,
+  layers,
+  customLayers,
+  buildSourceSpec,
+}: SourceLayersToggleProps) => {
+  const { mainMap } = useMap();
+  const mapReady = useCommonStore((state) => state.mapReady);
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    if (!mainMap) return;
+
+    const map = mainMap.getMap();
+
+    const handleStyleData = () => {
+      setEnabled(!!map.getSource(sourceId));
+    };
+
+    map.on('styledata', handleStyleData);
+
+    return () => {
+      map.off('styledata', handleStyleData);
+    };
+  }, [mainMap, sourceId]);
+
+  const applyLayers = useCallback(
+    (visible: boolean) => {
+      if (!mainMap || !mapReady) return;
+
+      const map = mainMap.getMap();
+      setEnabled(visible);
+
+      if (visible) {
+        if (!map.getSource(sourceId)) {
+          map.addSource(sourceId, buildSourceSpec());
+        }
+
+        for (const layer of layers) {
+          if (!map.getLayer(layer.id)) {
+            map.addLayer(layer);
+          }
+        }
+
+        for (const entry of customLayers) {
+          const layerSource =
+            'source' in entry.layer ? entry.layer.source : undefined;
+
+          if (layerSource !== sourceId || map.getLayer(entry.layer.id)) {
+            continue;
+          }
+
+          try {
+            map.addLayer(entry.layer);
+            if (!entry.visible) {
+              map.setLayoutProperty(entry.layer.id, 'visibility', 'none');
+            }
+          } catch {
+            // The layer can only be added after the source becomes available.
+          }
+        }
+        return;
+      }
+
+      for (const layer of layers) {
+        if (map.getLayer(layer.id)) {
+          map.removeLayer(layer.id);
+        }
+      }
+
+      for (const entry of customLayers) {
+        const layerSource =
+          'source' in entry.layer ? entry.layer.source : undefined;
+
+        if (layerSource !== sourceId || !map.getLayer(entry.layer.id)) {
+          continue;
+        }
+
+        map.removeLayer(entry.layer.id);
+      }
+
+      if (map.getSource(sourceId)) {
+        map.removeSource(sourceId);
+      }
+    },
+    [buildSourceSpec, customLayers, layers, mainMap, mapReady, sourceId]
+  );
+
+  if (!mapReady) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-3 p-3 bg-muted/50 rounded-md">
+      <Label
+        htmlFor={`${sourceId}-toggle`}
+        className="text-sm font-medium cursor-pointer"
+      >
+        {label}
+      </Label>
+      <Switch
+        id={`${sourceId}-toggle`}
+        checked={enabled}
+        onCheckedChange={applyLayers}
+        className="data-[state=checked]:bg-green-600"
+      />
+    </div>
+  );
+};

--- a/src/components/tiles/tiles.spec.tsx
+++ b/src/components/tiles/tiles.spec.tsx
@@ -392,8 +392,9 @@ describe('TilesControl', () => {
       const user = userEvent.setup();
       render(<TilesControl />);
 
-      const groupSwitches = screen.getAllByRole('switch');
-      const roadsGroupSwitch = groupSwitches[3]!;
+      const roadsGroupSwitch = screen.getByRole('switch', {
+        name: /roads group visibility/i,
+      });
 
       await user.click(roadsGroupSwitch);
 
@@ -418,8 +419,9 @@ describe('TilesControl', () => {
       const user = userEvent.setup();
       render(<TilesControl />);
 
-      const groupSwitches = screen.getAllByRole('switch');
-      const waterGroupSwitch = groupSwitches[2]!;
+      const waterGroupSwitch = screen.getByRole('switch', {
+        name: /water group visibility/i,
+      });
 
       await user.click(waterGroupSwitch);
       await user.click(waterGroupSwitch);

--- a/src/components/tiles/tiles.tsx
+++ b/src/components/tiles/tiles.tsx
@@ -14,7 +14,9 @@ import {
 import { ChevronDown, ChevronRight, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ValhallaLayersToggle } from './valhalla-layers-toggle';
+import { ExpansionLayersToggle } from './expansion-layers-toggle';
 import { VALHALLA_SOURCE_ID } from './valhalla-layers';
+import { EXPANSION_SOURCE_ID } from './expansion-layers';
 import { CustomLayerEditor } from './custom-layer-editor';
 
 interface LayerInfo {
@@ -216,6 +218,11 @@ export const TilesControl = () => {
     return layersInGroup.some((layer) => layer.source === VALHALLA_SOURCE_ID);
   };
 
+  const isExpansionGroup = (sourceLayer: string) => {
+    const layersInGroup = groupedLayers.grouped[sourceLayer] || [];
+    return layersInGroup.some((layer) => layer.source === EXPANSION_SOURCE_ID);
+  };
+
   const handleRemoveCustomLayer = (id: string) => {
     if (!mainMap) return;
     const map = mainMap.getMap();
@@ -240,6 +247,7 @@ export const TilesControl = () => {
   return (
     <div className="flex flex-col gap-3 flex-1 overflow-hidden min-h-0">
       <ValhallaLayersToggle customLayers={customLayers} />
+      <ExpansionLayersToggle customLayers={customLayers} />
 
       <div className="flex items-center justify-between gap-3 p-3 bg-muted/50 rounded-md">
         <Label
@@ -292,8 +300,14 @@ export const TilesControl = () => {
                       Valhalla
                     </span>
                   )}
+                  {isExpansionGroup(sourceLayer) && (
+                    <span className="text-xs bg-blue-600 text-white px-1.5 py-0.5 rounded ml-2">
+                      Expansion
+                    </span>
+                  )}
                 </CollapsibleTrigger>
                 <Switch
+                  aria-label={`${sourceLayer} group visibility`}
                   checked={isGroupVisible(sourceLayer)}
                   onCheckedChange={(checked) =>
                     handleToggleGroup(sourceLayer, checked)

--- a/src/components/tiles/valhalla-layers-toggle.tsx
+++ b/src/components/tiles/valhalla-layers-toggle.tsx
@@ -1,14 +1,10 @@
-import { useState, useEffect } from 'react';
-import { useMap } from 'react-map-gl/maplibre';
 import type { LayerSpecification } from 'maplibre-gl';
-import { useCommonStore } from '@/stores/common-store';
-import { Switch } from '@/components/ui/switch';
-import { Label } from '@/components/ui/label';
 import {
   VALHALLA_SOURCE_ID,
   VALHALLA_LAYERS,
   getValhallaSourceSpec,
 } from './valhalla-layers';
+import { SourceLayersToggle } from './source-layers-toggle';
 
 interface ValhallaLayersToggleProps {
   customLayers: { layer: LayerSpecification; visible: boolean }[];
@@ -17,101 +13,13 @@ interface ValhallaLayersToggleProps {
 export const ValhallaLayersToggle = ({
   customLayers,
 }: ValhallaLayersToggleProps) => {
-  const { mainMap } = useMap();
-  const mapReady = useCommonStore((state) => state.mapReady);
-  const [enabled, setEnabled] = useState(false);
-
-  useEffect(() => {
-    if (!mainMap) return;
-
-    const map = mainMap.getMap();
-
-    const handleStyleData = () => {
-      const hasSource = !!map.getSource(VALHALLA_SOURCE_ID);
-      setEnabled(hasSource);
-    };
-
-    map.on('styledata', handleStyleData);
-
-    return () => {
-      map.off('styledata', handleStyleData);
-    };
-  }, [mainMap]);
-
-  const handleToggle = (checked: boolean) => {
-    if (!mainMap || !mapReady) return;
-
-    const map = mainMap.getMap();
-    setEnabled(checked);
-
-    if (checked) {
-      if (!map.getSource(VALHALLA_SOURCE_ID)) {
-        map.addSource(VALHALLA_SOURCE_ID, getValhallaSourceSpec());
-      }
-      for (const layer of VALHALLA_LAYERS) {
-        if (!map.getLayer(layer.id)) {
-          map.addLayer(layer);
-        }
-      }
-      for (const entry of customLayers) {
-        const layerSource =
-          'source' in entry.layer ? entry.layer.source : undefined;
-        if (
-          layerSource === VALHALLA_SOURCE_ID &&
-          !map.getLayer(entry.layer.id)
-        ) {
-          try {
-            map.addLayer(entry.layer);
-            if (!entry.visible) {
-              map.setLayoutProperty(entry.layer.id, 'visibility', 'none');
-            }
-          } catch {
-            // skip
-          }
-        }
-      }
-    } else {
-      for (const layer of VALHALLA_LAYERS) {
-        if (map.getLayer(layer.id)) {
-          map.removeLayer(layer.id);
-        }
-      }
-
-      for (const entry of customLayers) {
-        const layerSource =
-          'source' in entry.layer ? entry.layer.source : undefined;
-        if (
-          layerSource === VALHALLA_SOURCE_ID &&
-          map.getLayer(entry.layer.id)
-        ) {
-          map.removeLayer(entry.layer.id);
-        }
-      }
-
-      if (map.getSource(VALHALLA_SOURCE_ID)) {
-        map.removeSource(VALHALLA_SOURCE_ID);
-      }
-    }
-  };
-
-  if (!mapReady) {
-    return null;
-  }
-
   return (
-    <div className="flex items-center justify-between gap-3 p-3 bg-muted/50 rounded-md">
-      <Label
-        htmlFor="valhalla-layers-toggle"
-        className="text-sm font-medium cursor-pointer"
-      >
-        Append Valhalla layers
-      </Label>
-      <Switch
-        id="valhalla-layers-toggle"
-        checked={enabled}
-        onCheckedChange={handleToggle}
-        className="data-[state=checked]:bg-green-600"
-      />
-    </div>
+    <SourceLayersToggle
+      label="Append Valhalla layers"
+      sourceId={VALHALLA_SOURCE_ID}
+      layers={VALHALLA_LAYERS}
+      customLayers={customLayers}
+      buildSourceSpec={getValhallaSourceSpec}
+    />
   );
 };

--- a/src/components/tiles/valhalla-layers.spec.ts
+++ b/src/components/tiles/valhalla-layers.spec.ts
@@ -19,6 +19,8 @@ import {
   VALHALLA_LAYERS,
   getValhallaTileUrl,
   getValhallaSourceSpec,
+  getExpansionTileUrl,
+  getExpansionSourceSpec,
 } from './valhalla-layers';
 
 vi.mock('@/utils/base-url', () => ({
@@ -275,6 +277,29 @@ describe('valhalla-layers', () => {
       const spec = getValhallaSourceSpec() as VectorSourceSpecification;
 
       expect(spec.scheme).toBe('xyz');
+    });
+  });
+
+  describe('getExpansionTileUrl', () => {
+    it('should return correctly formatted expansion tile URL', () => {
+      const url = getExpansionTileUrl();
+
+      expect(url).toContain('https://valhalla.example.com/expansion?json=');
+      expect(url).toContain('{z}');
+      expect(url).toContain('{x}');
+      expect(url).toContain('{y}');
+    });
+  });
+
+  describe('getExpansionSourceSpec', () => {
+    it('should return vector source spec for expansion tiles', () => {
+      const spec = getExpansionSourceSpec() as VectorSourceSpecification;
+
+      expect(spec.type).toBe('vector');
+      expect(spec.tiles).toHaveLength(1);
+      expect(spec.tiles![0]).toContain(
+        'https://valhalla.example.com/expansion'
+      );
     });
   });
 });

--- a/src/components/tiles/valhalla-layers.ts
+++ b/src/components/tiles/valhalla-layers.ts
@@ -15,19 +15,35 @@ export const VALHALLA_ACCESS_RESTRICTIONS_TIMED_LAYER_ID =
 const TILE_JSON_ENCODED =
   '%7B%22verbose%22%3A%20true%2C%20%22tile%22%3A%7B%22z%22%3A{z}%2C%22x%22%3A{x}%2C%22y%22%3A{y}%7D%7D';
 
-export function getValhallaTileUrl(): string {
+function getValhallaVectorTileUrl(endpoint: string): string {
   const baseUrl = normalizeBaseUrl(getBaseUrl());
-  return `${baseUrl}/tile?json=${TILE_JSON_ENCODED}`;
+  return `${baseUrl}/${endpoint}?json=${TILE_JSON_ENCODED}`;
 }
 
-export function getValhallaSourceSpec(): SourceSpecification {
+function getValhallaVectorSourceSpec(endpoint: string): SourceSpecification {
   return {
     type: 'vector',
-    tiles: [getValhallaTileUrl()],
+    tiles: [getValhallaVectorTileUrl(endpoint)],
     minzoom: 7,
     maxzoom: 14,
     scheme: 'xyz',
   };
+}
+
+export function getValhallaTileUrl(): string {
+  return getValhallaVectorTileUrl('tile');
+}
+
+export function getExpansionTileUrl(): string {
+  return getValhallaVectorTileUrl('expansion');
+}
+
+export function getValhallaSourceSpec(): SourceSpecification {
+  return getValhallaVectorSourceSpec('tile');
+}
+
+export function getExpansionSourceSpec(): SourceSpecification {
+  return getValhallaVectorSourceSpec('expansion');
 }
 
 export const VALHALLA_EDGES_LAYER: LayerSpecification = {


### PR DESCRIPTION
- Add a reusable source-layer toggle for vector tile sources.
- Add expansion layer helpers and a visible expansion debug layer.
- Wire the map and tiles panel to query and display expansion features.
- Update popup labeling and tests for the new expansion flow.