### PR TITLE
Fit route bounds including waypoints

### DIFF
--- a/src/components/directions/summary.tsx
+++ b/src/components/directions/summary.tsx
@@ -56,12 +56,12 @@ export const Summary = ({
     if (!mainMap || routeCoordinates.length === 0) return;
 
     const firstCoord = routeCoordinates[0];
-    if (!firstCoord || !firstCoord[0] || !firstCoord[1]) return;
+    if (!firstCoord || firstCoord[0] == null || firstCoord[1] == null) return;
 
     const bounds: [[number, number], [number, number]] =
       routeCoordinates.reduce<[[number, number], [number, number]]>(
         (acc, coord) => {
-          if (!coord || !coord[0] || !coord[1]) return acc;
+          if (!coord || coord[0] == null || coord[1] == null) return acc;
           return [
             [Math.min(acc[0][0], coord[1]), Math.min(acc[0][1], coord[0])],
             [Math.max(acc[1][0], coord[1]), Math.max(acc[1][1], coord[0])],

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -447,7 +447,7 @@ export const MapComponent = () => {
 
     //First Point
     const firstCoord = coordinates[0];
-    if (!firstCoord || !firstCoord[0] || !firstCoord[1]) return;
+    if (!firstCoord || firstCoord[0] == null || firstCoord[1] == null) return;
 
     //Last Point
     const lastCoord = coordinates[coordinates.length - 1]!;
@@ -464,14 +464,14 @@ export const MapComponent = () => {
       lastCoord[1];
     //Compare with what was last zoomed
     if (coordKey === lastZoomedCoordKeyRef.current) return;
-    //Store thr new Key
+    //Store the new Key
     lastZoomedCoordKeyRef.current = coordKey;
 
     const bounds: [[number, number], [number, number]] = coordinates.reduce<
       [[number, number], [number, number]]
     >(
       (acc, coord) => {
-        if (!coord || !coord[0] || !coord[1]) return acc;
+        if (!coord || coord[0] == null || coord[1] == null) return acc;
         return [
           [Math.min(acc[0][0], coord[1]), Math.min(acc[0][1], coord[0])],
           [Math.max(acc[1][0], coord[1]), Math.max(acc[1][1], coord[0])],

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -467,7 +467,7 @@ export const MapComponent = () => {
     //Store the new Key
     lastZoomedCoordKeyRef.current = coordKey;
 
-    const bounds: [[number, number], [number, number]] = coordinates.reduce<
+    const routeBounds = coordinates.reduce<
       [[number, number], [number, number]]
     >(
       (acc, coord) => {
@@ -482,6 +482,20 @@ export const MapComponent = () => {
         [firstCoord[1], firstCoord[0]],
       ]
     );
+
+    //Markers sit on the geocoded address, which can be off the routed
+    //geometry - include the ones belonging to this tab so they stay in view
+    const activeTabMarkerType =
+      activeTab === 'isochrones' ? 'isocenter' : 'waypoint';
+    const bounds = markers
+      .filter((marker) => marker.type === activeTabMarkerType)
+      .reduce<[[number, number], [number, number]]>(
+        (acc, marker) => [
+          [Math.min(acc[0][0], marker.lng), Math.min(acc[0][1], marker.lat)],
+          [Math.max(acc[1][0], marker.lng), Math.max(acc[1][1], marker.lat)],
+        ],
+        routeBounds
+      );
 
     //Read panel from the store directly
     //avoids re-running the effect when panels open or close
@@ -507,9 +521,9 @@ export const MapComponent = () => {
       },
       maxZoom: coordinates.length === 1 ? 11 : 18,
     });
-    //only rerun when coordinates change
+    //the coordKey guard above keeps this to one fit per route
     //panel change no longer rerun this
-  }, [coordinates]);
+  }, [coordinates, markers, activeTab]);
 
   const handleMapTilesClick = useCallback(
     (event: maplibregl.MapLayerMouseEvent) => {


### PR DESCRIPTION
## 👨‍💻 Changes proposed

Include the waypoint positions in the calculated bounds for the route.
If the waypoint is not directly on the route it may be off-screen otherwise.

If any x or y coordinate is exactly zero it was not included in the bounds.
If x or y of the start is exactly zero no bounds fitting took place.

## 📄 Note to reviewers

Example route (markers offscreen after fit):
https://valhalla.openstreetmap.de/directions?profile=car&style=carto&alternates=1&lang=de-DE&wps=12.879597133807124%2C63.50063786698544%2C12.977819149130966%2C63.56108239540447
If you drag marker 2 slightly it centers on the route and you need to zoom out before you can see it again.

Example route x of start position is zero:
http://valhalla.local/directions?profile=bicycle&style=carto&wps=0%2C52.049586%2C0.008573172345307967%2C52.088571687614746&lang=de-DE

## 📷 Screenshots
<img width="919" height="511" alt="image" src="https://github.com/user-attachments/assets/76fa823a-6f90-4fc3-82f5-f6f638495ea7" />